### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pizza-gui"
-version = "0.1.5"
+version = "0.1.6"
 description = "Pizza desktop GUI"
 edition = "2021"
 rust-version = "1.77"

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Pizza",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"identifier": "ai.pizza.gui",
 	"build": {
 		"beforeDevCommand": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pizza-web",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pizza-web",
-			"version": "0.1.5",
+			"version": "0.1.6",
 			"dependencies": {
 				"@pizza/protocol": "file:../packages/protocol",
 				"@pxlkit/ui-kit": "^2.0.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pizza-web",
 	"private": true,
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tomsun28/pizza",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tomsun28/pizza",
-			"version": "0.1.5",
+			"version": "0.1.6",
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "^0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tomsun28/pizza",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Pizza - Pizza is an event-driven agent. Every conversation, tool call, and file edit is an event in an immutable log. Your UI, the LLM context, and the session tree are all projections of that log.",
 	"type": "module",
 	"pizzaConfig": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pizza/protocol",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"private": true,
 	"type": "module",
 	"main": "./index.ts",


### PR DESCRIPTION
Bump version from 0.1.5 to 0.1.6 for re-release (0.1.5 was already published to npm).

Generated with [Devin](https://devin.ai)