### PR TITLE
fix: reflect live model changes in LLM calls and normalize image mimeType in USER_MESSAGE projection

### DIFF
--- a/src/core/projection/event-to-message.ts
+++ b/src/core/projection/event-to-message.ts
@@ -53,13 +53,22 @@ export function eventToMessage(event: EventBase): AgentMessage | null {
 	switch (event.type) {
 		case "USER_MESSAGE": {
 			const payload = event.payload as UserMessageEvent["payload"];
-			// Merge images into content array if present
+			// Merge images into content array if present.
+			// Event-store images use snake_case `mime_type`; pi-ai's ImageContent
+			// uses camelCase `mimeType`. Convert here so the LLM payload builder
+			// (openai-completions etc.) reads the correct field — otherwise it
+			// emits `data:undefined;base64,...` and the provider returns 400.
 			let content: string | (TextContent | ImageContent)[] = payload.content as string | (TextContent | ImageContent)[];
 			if (payload.images && payload.images.length > 0) {
+				const images: ImageContent[] = payload.images.map((img) => ({
+					type: "image" as const,
+					data: img.data,
+					mimeType: (img as { mimeType?: string; mime_type?: string }).mimeType ?? img.mime_type,
+				}));
 				if (typeof content === "string") {
-					content = [{ type: "text", text: content } as TextContent, ...(payload.images as any)];
+					content = [{ type: "text", text: content } as TextContent, ...images];
 				} else {
-					content = [...content, ...(payload.images as any)];
+					content = [...content, ...images];
 				}
 			}
 			return {

--- a/src/core/runtime/ai-client.ts
+++ b/src/core/runtime/ai-client.ts
@@ -28,7 +28,12 @@ function getStreamToolCall(event: AssistantMessageEvent): ToolCall | undefined {
 
 /** Build an EventSourcedRuntime LLMClient around the configured AI stream function. */
 export function buildLlmClientFromStreamFn(
-	model: Model<any>,
+	/**
+	 * Getter for the current model. Read at request time so live model changes
+	 * (e.g. via /model, RPC set_model, or extensions) are reflected in both the
+	 * API call and the model metadata exposed to tools via ctx.model.
+	 */
+	getModel: () => Model<any> | undefined,
 	streamFn: AiStreamFn,
 	options?: {
 		getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
@@ -45,6 +50,10 @@ export function buildLlmClientFromStreamFn(
 ): LLMClient {
 	return {
 		async complete({ messages, systemPrompt, tools, onChunk, signal }) {
+			const model = getModel();
+			if (!model) {
+				throw new Error("No model configured");
+			}
 			const apiKey = options?.getApiKey ? await options.getApiKey(model.provider) : undefined;
 			// Read the current thinking level at request time (not build time) so
 			// runtime changes via /thinking or setThinkingLevel() are honored.

--- a/src/core/session-facade-factory.ts
+++ b/src/core/session-facade-factory.ts
@@ -314,6 +314,18 @@ export async function createSessionFacade(
 	};
 
 	let runtime: EventSourcedRuntime | undefined;
+	// Live model getter: reads the runtime's current model config + registry so
+	// that model switches (via /model, RPC set_model, or extensions) are reflected
+	// in both LLM API calls and ctx.model for tools. Falls back to the closure
+	// `model` if the registry lookup fails (e.g. the model was removed).
+	const getModelLive = (): Model<any> | undefined => {
+		const cfg = runtime?.getModel();
+		if (cfg) {
+			const resolved = modelRegistry.find(cfg.provider, cfg.model_id);
+			if (resolved) return resolved;
+		}
+		return model;
+	};
 	let activeToolDefinitions: ExtensionToolDefinition[] = [];
 	let availableToolDefinitions: ExtensionToolDefinition[] = [];
 	let availableToolSources = new Map<string, ToolInfo["sourceInfo"]>();
@@ -543,7 +555,7 @@ export async function createSessionFacade(
 			},
 		},
 		{
-			getModel: () => model,
+			getModel: getModelLive,
 			isIdle: () => !runtime?.isRunning,
 			getSignal: () => runtime?.signal,
 			abort: () => runtime?.abort(),
@@ -569,7 +581,7 @@ export async function createSessionFacade(
 
 	// ── LLM client (AI stream function -> reactor LLMClient) ───────────────
 	const llmClient = model
-		? buildLlmClientFromStreamFn(model, async (m, context, opts) => {
+		? buildLlmClientFromStreamFn(getModelLive, async (m, context, opts) => {
 				const auth = await modelRegistry.getApiKeyAndHeaders(m);
 				if (!auth.ok) {
 					throw new Error(auth.error);

--- a/test/print-mode.test.ts
+++ b/test/print-mode.test.ts
@@ -134,7 +134,7 @@ describe("runPrintModeWithFacade", () => {
 		const userMessage = requestMessages.find((message) => message.role === "user");
 		expect(userMessage?.content).toEqual([
 			{ type: "text", text: "Describe" },
-			{ type: "image", data: "abc", mime_type: "image/png" },
+			{ type: "image", data: "abc", mimeType: "image/png" },
 		]);
 	});
 });


### PR DESCRIPTION
# Description

Two related runtime fixes:

- **Live model getter for LLM client**: `buildLlmClientFromStreamFn` now takes a `getModel()` getter instead of a captured `Model` instance, so model switches (via `/model`, RPC `set_model`, or extensions) are reflected in both the API call and the model metadata exposed to tools via `ctx.model`. `createSessionFacade` wires this up with `getModelLive`, which reads the runtime's current model config + registry and falls back to the closure `model` if the lookup fails.
- **Normalize image `mime_type` -> `mimeType` in USER_MESSAGE projection**: event-store images use snake_case `mime_type`, while pi-ai's `ImageContent` uses camelCase `mimeType`. The projection now converts the field so the LLM payload builder reads the correct field — previously it emitted `data:undefined;base64,...` and the provider returned 400.

## Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/tomsun28/pizza/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Appropriate docs were updated (if necessary)

#### Test plan
- [x] Updated `test/print-mode.test.ts` to assert the projected image uses `mimeType` (camelCase).
- [ ] Manually verify a `/model` switch mid-session picks up the new model on the next turn.

Generated with [Devin](https://devin.ai)