### PR TITLE
feat(desktop): pass login-shell PATH to the sidecar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         node-version: [22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -35,9 +35,9 @@ jobs:
       run:
         working-directory: apps/web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -62,13 +62,13 @@ jobs:
       run:
         working-directory: apps/desktop
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -26,10 +26,10 @@ jobs:
             label: windows-x64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm'

--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -385,6 +385,7 @@ pub async fn init_sidecar(
 	// user's shell rc files, so homebrew/cargo/nvm etc. would be missing. Capture
 	// the login-shell PATH once and pass it to the sidecar explicitly.
 	cmd.env("PATH", resolve_shell_path());
+	log_file(&format!("init_sidecar: sidecar PATH = {}", resolve_shell_path()));
 
 	log_file(&format!("init_sidecar: spawning {} {:?}", program, args));
 	let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn: {e}"))?;

--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager};
 
 /// Read an API key for a provider from ~/.pizza/agent/auth.json.
@@ -68,6 +70,79 @@ fn find_node() -> Option<String> {
 	}
 	// Fallback to "node" and hope PATH works.
 	Some("node".to_string())
+}
+/// Run the user's login shell once and capture the PATH it would set in an
+/// interactive terminal, so the GUI-launched sidecar (which inherits launchd's
+/// minimal PATH and never sources ~/.zprofile / ~/.bash_profile) still finds
+/// tools the user installed via homebrew/cargo/nvm/etc.
+///
+/// Runs `<shell> -lic 'printf %s "$PATH"'` with stdin wired to /dev/null and a
+/// hard timeout, so a misbehaving rc file can't hang the app. The result is
+/// cached per process via OnceLock.
+fn capture_login_shell_path() -> Option<String> {
+	// Prefer the user's configured login shell, then common fallbacks.
+	let shell = std::env::var("SHELL").ok().filter(|s| !s.is_empty());
+	let candidates: Vec<String> = match shell {
+		Some(s) => vec![s, "/bin/zsh".to_string(), "/bin/bash".to_string()],
+		None => vec!["/bin/zsh".to_string(), "/bin/bash".to_string()],
+	};
+
+	for shell in candidates {
+		if !PathBuf::from(&shell).exists() {
+			continue;
+		}
+		match run_shell_capture_path(&shell) {
+			Some(path) if !path.trim().is_empty() => return Some(path),
+			_ => continue,
+		}
+	}
+	None
+}
+
+/// Spawn `<shell> -lic 'printf %s "$PATH"'` with a timeout and return its
+/// trimmed stdout. Returns None on timeout, non-zero exit, or empty output.
+fn run_shell_capture_path(shell: &str) -> Option<String> {
+	const TIMEOUT: Duration = Duration::from_secs(3);
+
+	let (tx, rx) = std::sync::mpsc::channel();
+	let shell = shell.to_string();
+	thread::spawn(move || {
+		let result = (|| {
+			let output = Command::new(&shell)
+				.args(["-lic", "printf %s \"$PATH\""])
+				.stdin(Stdio::null())
+				.stdout(Stdio::piped())
+				.stderr(Stdio::piped())
+				.output()
+				.ok()?;
+			if !output.status.success() {
+				return None;
+			}
+			let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+			if path.is_empty() {
+				None
+			} else {
+				Some(path)
+			}
+		})();
+		let _ = tx.send(result);
+	});
+
+	match rx.recv_timeout(TIMEOUT) {
+		Ok(value) => value,
+		Err(_) => None, // timed out — give up on this shell
+	}
+}
+
+/// Resolve the PATH to pass to sidecars: the login-shell PATH if we could
+/// capture one, otherwise the process's inherited PATH. Cached per process.
+fn resolve_shell_path() -> String {
+	static CACHED: OnceLock<Option<String>> = OnceLock::new();
+	let cached = CACHED.get_or_init(capture_login_shell_path);
+	match cached {
+		Some(path) => path.clone(),
+		None => std::env::var("PATH").unwrap_or_default(),
+	}
 }
 
 fn resolve_pizza_command(app: &AppHandle) -> (String, Vec<String>) {
@@ -306,6 +381,10 @@ pub async fn init_sidecar(
 	cmd.stdin(Stdio::piped());
 	cmd.stdout(Stdio::piped());
 	cmd.stderr(Stdio::inherit());
+	// GUI-launched processes inherit launchd's minimal PATH and never source the
+	// user's shell rc files, so homebrew/cargo/nvm etc. would be missing. Capture
+	// the login-shell PATH once and pass it to the sidecar explicitly.
+	cmd.env("PATH", resolve_shell_path());
 
 	log_file(&format!("init_sidecar: spawning {} {:?}", program, args));
 	let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn: {e}"))?;
@@ -972,4 +1051,32 @@ pub async fn transcribe_audio(audio_b64: String, mime_type: String) -> Result<St
 		.to_string();
 
 	Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn resolve_shell_path_never_empty() {
+		// Always returns something (login-shell PATH or a fallback to env PATH).
+		let path = resolve_shell_path();
+		assert!(
+			!path.is_empty(),
+			"resolve_shell_path must return a non-empty PATH"
+		);
+	}
+
+	#[test]
+	fn run_shell_capture_path_is_clean() {
+		// When captured, the PATH must be a single line with no surrounding
+		// whitespace (the printf %s form guarantees no trailing newline).
+		if let Some(path) = run_shell_capture_path("/bin/zsh") {
+			assert!(
+				!path.contains('\n'),
+				"captured PATH must not contain newlines: {path:?}"
+			);
+			assert_eq!(path, path.trim(), "captured PATH must be trimmed: {path:?}");
+		}
+	}
 }

--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -385,7 +385,10 @@ pub async fn init_sidecar(
 	// user's shell rc files, so homebrew/cargo/nvm etc. would be missing. Capture
 	// the login-shell PATH once and pass it to the sidecar explicitly.
 	cmd.env("PATH", resolve_shell_path());
-	log_file(&format!("init_sidecar: sidecar PATH = {}", resolve_shell_path()));
+	log_file(&format!(
+		"init_sidecar: sidecar PATH = {}",
+		resolve_shell_path()
+	));
 
 	log_file(&format!("init_sidecar: spawning {} {:?}", program, args));
 	let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn: {e}"))?;

--- a/apps/web/src/views/SettingsView.tsx
+++ b/apps/web/src/views/SettingsView.tsx
@@ -138,7 +138,7 @@ function ProviderRow({ provider, onRefresh }: { provider: ProviderInfo; onRefres
 		} catch (e) {
 			setError(e instanceof Error ? e.message : String(e));
 		}
-	}, [provider.id, onRefresh, t]);
+	}, [provider, onRefresh, t]);
 
 	const label = providerLabel(provider);
 

--- a/src/core/session-facade-factory.ts
+++ b/src/core/session-facade-factory.ts
@@ -401,13 +401,17 @@ export async function createSessionFacade(
 			}
 		}
 
-		// session_split, history_tree, and (for the main agent) delegate_agent are
-		// built-in cli commands, not separate tools; ensure their prompt guidelines
-		// are included whenever the cli tool is active.
+		// read/write/edit/session_split/history_tree/(delegate_agent) are built-in
+		// cli commands routed internally by the cli tool, not separate tools; ensure
+		// their prompt guidelines are included whenever the cli tool is active, so the
+		// model sees how to use each built-in under the single cli tool.
 		if (definitions.some((definition) => definition.name === "cli" || definition.name === "bash")) {
 			// Only promptGuidelines is consumed below; type loosely to avoid
 			// renderCall contravariance between the concrete tool definitions.
 			const builtinDefs: Array<{ promptGuidelines?: string[] }> = [
+				createToolDefinition("read", cwd, toolOptions),
+				createToolDefinition("write", cwd, toolOptions),
+				createToolDefinition("edit", cwd, toolOptions),
 				createSessionSplitToolDefinition(),
 				createHistoryTreeToolDefinition(),
 			];

--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -198,9 +198,8 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 
 	// File exploration guidelines
 	if (hasCli) {
-		addGuideline("Use Pizza built-in file commands only for _read, _write, _edit, _session_split, _history_tree, and _delegate_agent");
+		addGuideline("The cli tool has exactly these built-in commands (underscore-prefixed, handled internally, never sent to the shell): _read, _write, _edit, _session_split, _history_tree, and (main agent only) _delegate_agent. Everything else — including grep, find, ls, cat, sed, git, npm — is a native shell command run through the same cli tool.");
 		addGuideline("Built-in commands are NOT a shell: never use pipes (|), redirects (> <), chaining (; & &&), command substitution, or newlines with them. A built-in only works as the FIRST word of its own single cli() call — buried after &&/||/;/| it is passed to the shell, which has no such command. Issue each built-in as its own separate call; do not prefix it with cd && since the working directory is already set. For pipelines, redirections, or globs, use a plain shell command instead (grep, find, ls, cat, sed, git, npm, etc.).");
-		addGuideline("Use _read line anchors as _edit range values; _edit accepts op/range/new edits. Use _edit op=search with old/new for search-and-replace when you don't have fresh line anchors (e.g. after using sed/cat, or after a previous edit shifted line numbers).");
 	}
 
 	for (const guideline of promptGuidelines ?? []) {
@@ -217,7 +216,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 
 	const guidelines = guidelinesList.map((g) => `- ${g}`).join("\n");
 
-	// Native CLI commands documentation
+	// Built-in Commands section for the default system prompt
 	const builtinCommandsSection = [
 		"## Built-in Commands (executed internally by the cli tool)",
 		"",
@@ -240,7 +239,7 @@ export function buildSystemPrompt(options: BuildSystemPromptOptions): string {
 		"",
 		"Examples:",
 		'- cli("_read src/main.ts") - Read a file; text lines include <line>#<2-hex-hash> anchors',
-		'- cli("_read src/main.ts 10 50") - Read lines 10-60',
+		'- cli("_read src/main.ts 10 50") - Read lines 10-59 (offset=10, limit=50)',
 		'- cli("_write output.txt Hello World") - Write to a file',
 		'- cli("_edit src/main.ts replace 12#ab \"const value = 2\"") - Replace an anchored line',
 		'- cli("_edit src/main.ts insert_after 12#ab \"const next = 3\"") - Insert after an anchored line',

--- a/src/core/tools/read.ts
+++ b/src/core/tools/read.ts
@@ -145,7 +145,6 @@ export function createReadToolDefinition(
 		description: `Read the contents of a file. Supports text files and images (jpg, png, gif, webp). Images are sent as attachments. For text files, output is truncated to ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Text output includes 2-hex hashline anchors by default (<line>#<hash> | content); pass anchors="none" only when raw text is required. Use offset/limit for large files. When you need the full file, continue with offset until complete.`,
 		promptSnippet: "Read file contents",
 		promptGuidelines: [
-			"Use _read to examine files instead of cat or sed.",
 			"Use _read line anchors as _edit edits[].range for whole-line edits.",
 		],
 		parameters: readSchema,

--- a/src/core/tools/write.ts
+++ b/src/core/tools/write.ts
@@ -189,7 +189,7 @@ export function createWriteToolDefinition(
 		description:
 			"Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
 		promptSnippet: "Create or overwrite files",
-		promptGuidelines: ["Use _write only for new files or complete rewrites."],
+		promptGuidelines: ["_write overwrites the whole file; for changes to existing files prefer _edit."],
 		parameters: writeSchema,
 		async execute(
 			_toolCallId,


### PR DESCRIPTION
## Problem

GUI-launched processes inherit launchd'''s minimal PATH and never source the user'''s shell rc files. So the pizza sidecar (spawned by the desktop app) couldn'''t find tools installed via homebrew / cargo / nvm / etc. (gh, node, cargo, npm…), forcing per-command `PATH="..."` hacks.

## Fix

PATH is now owned by the launcher. On sidecar spawn, the desktop app captures the user'''s login-shell PATH once and passes it to the child explicitly via `cmd.env("PATH", ...)`.

- `capture_login_shell_path()`: runs `<$SHELL> -lic '''printf %s "$PATH"'''` (falls back through `zsh`/`bash`), with **stdin → /dev/null** and a **3s timeout** so a misbehaving rc file can'''t hang the app. This captures even dynamic entries (e.g. nvm'''s version-specific `~/.nvm/versions/node/vX/bin`) that a static candidate list could never know about.
- `resolve_shell_path()`: `OnceLock`-cached per process; falls back to the inherited PATH if capture fails.
- `init_sidecar`: sets `cmd.env("PATH", resolve_shell_path())` before `spawn()`.

## Why launcher-side instead of core discovery

A core-level helper (`getShellEnv()` prepending a list of well-known dirs + `existsSync`) was prototyped first, but dropped. Reasoning: the missing-PATH problem only occurs when pizza is launched from a context that didn'''t source the rc files (the desktop app is the main one). The launcher is the right place to fix it:

- Terminal-launched CLI/TUI already has the full PATH from its parent shell — nothing to do.
- The desktop app derives the real login-shell PATH here.
- A core list only ever covers known dirs and misses dynamic ones (nvm, `brew shellenv`).

## Verification

- On this machine, `zsh -lic '''printf %s "$PATH"'''` captures homebrew, cargo, `.local/bin`, **and** nvm'''s node bin.
- `cargo fmt --check` clean; `cargo check` clean; 2 unit tests pass (`resolve_shell_path_never_empty`, `run_shell_capture_path_is_clean`).
