### PR TITLE
ci(release): trigger publish on GitHub Release instead of tag push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

The `0.1.8` release was published (GitHub Release + tag both at `55fd8d6`) but the Release workflow never ran, so it was not published to npm.

Root cause: the workflow was triggered by `on: push.tags: 'v*.*.*'`, but the Release created a tag named `0.1.8` (no `v` prefix), which does not match the glob. There was also no `on: release` listener, so the `release: published` event was ignored entirely.

## Change

Switch the Release workflow trigger from a tag push to the GitHub Release event itself:

\`\`\`yaml
on:
  release:
    types: [published]
\`\`\`

Publishing a GitHub Release now drives `npm publish` directly, regardless of tag naming. Drafts and prereleases do not trigger it.

## Notes / follow-up

- This only affects **future** releases; `0.1.8` still needs to be published to npm separately (e.g. delete + re-create the `0.1.8` Release after this merges, or a local `npm publish`).
- The version published still comes from `package.json`, independent of the trigger or tag name.