### PR TITLE
ci: unify release triggers to GitHub Release published

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -1,9 +1,8 @@
 name: Desktop Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,8 @@ name: Release
 on:
   release:
     types: [published]
-
+  workflow_dispatch:
+  
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
## Summary

- **desktop-release**: Switch trigger from `push: tags: v*.*.*` to `release: types: [published]`, aligning with the release workflow
- **release**: Add `workflow_dispatch` trigger for manual runs

## Changes

- `.github/workflows/desktop-release.yaml`: Replace tag push trigger with release published trigger
- `.github/workflows/release.yaml`: Add `workflow_dispatch` trigger