### PR TITLE
fix(ci): add tag_name input to desktop-release workflow 

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (required for manual runs)'
+        required: true
 
 permissions:
   contents: write
@@ -115,12 +119,12 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
           files: |
             artifacts/**/*.dmg
             artifacts/**/*.deb
             artifacts/**/*.rpm
-            artifacts/**/*.AppImage
             artifacts/**/*.msi
             artifacts/**/*.exe
           generate_release_notes: true
-          draft: true
+          draft: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
…lish on GitHub Release

- Add tag_name input for manual workflow_dispatch runs (required field)
- Use inputs.tag_name for manual runs, fallback to github.ref_name for release events
- Remove .AppImage from release artifacts (no longer built)
- Set draft: true only for manual runs; auto-publish for GitHub Release events

# Description

<!-- Thanks for opening a Pull Request, Describe Your PR Here -->



## Checklist

<!-- Before submitting your PR, there are a few things you can do to make sure it goes smoothly: -->

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/tomsun28/pizza/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number>
