### PR TITLE
ci(desktop): remove macos x64 build and add platform name to artifact filenames

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -91,6 +91,43 @@ jobs:
           LABEL: ${{ matrix.label }}
         shell: bash
 
+      - name: Rename artifacts with platform name
+        run: |
+          LABEL="${{ matrix.label }}"
+          PLATFORM="${LABEL%%-*}"
+          ARCH="${LABEL##*-}"
+          BUNDLE_DIR="apps/desktop/target/release/bundle"
+          VERSION=$(grep -o '"version": "[^"]*"' apps/desktop/tauri.conf.json | head -1 | cut -d'"' -f4)
+
+          find "$BUNDLE_DIR" -type f \( -name "*.dmg" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.msi" \) | while read -r file; do
+            dir=$(dirname "$file")
+            base=$(basename "$file")
+            ext="${base##*.}"
+            case "$ext" in
+              dmg|deb|rpm)
+                new_name="Pizza_${VERSION}_${PLATFORM}_${ARCH}.${ext}"
+                ;;
+              exe)
+                if [[ "$base" == *"-setup.exe" ]]; then
+                  new_name="Pizza_${VERSION}_${PLATFORM}_${ARCH}-setup.exe"
+                else
+                  new_name="Pizza_${VERSION}_${PLATFORM}_${ARCH}.exe"
+                fi
+                ;;
+              msi)
+                lang=$(echo "$base" | sed -n "s/.*_\(.*\)\.msi/\1/p")
+                if [ -n "$lang" ]; then
+                  new_name="Pizza_${VERSION}_${PLATFORM}_${ARCH}_${lang}.msi"
+                else
+                  new_name="Pizza_${VERSION}_${PLATFORM}_${ARCH}.msi"
+                fi
+                ;;
+            esac
+            mv "$file" "$dir/$new_name"
+            echo "Renamed: $base -> $new_name"
+          done
+        shell: bash
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (required for manual runs)'
+        required: true
 
 permissions:
   contents: write
@@ -115,12 +119,12 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag_name || github.ref_name }}
           files: |
             artifacts/**/*.dmg
             artifacts/**/*.deb
             artifacts/**/*.rpm
-            artifacts/**/*.AppImage
             artifacts/**/*.msi
             artifacts/**/*.exe
           generate_release_notes: true
-          draft: true
+          draft: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Changes

- Remove `macos-13` (x86_64) from build matrix, only keep `macos-14` (arm64) for macOS
- Add post-build rename step to include platform and arch in artifact filenames

## Resulting artifact names

| Before | After |
|---|---|
| `Pizza_0.1.8_x64.dmg` | `Pizza_0.1.8_macos_arm64.dmg` |
| `Pizza_0.1.8_amd64.deb` | `Pizza_0.1.8_linux_x64.deb` |
| `Pizza-0.1.8-1.x86_64.rpm` | `Pizza_0.1.8_linux_x64.rpm` |
| `Pizza_0.1.8_x64-setup.exe` | `Pizza_0.1.8_windows_x64-setup.exe` |
| `Pizza_0.1.8_x64_en-US.msi` | `Pizza_0.1.8_windows_x64_en-US.msi` |