### PR TITLE
feat(desktop): add Plugins UI with skills directory and local skill 

### DIFF
--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -191,21 +191,23 @@ fn resolve_pizza_command(app: &AppHandle) -> (String, Vec<String>) {
 	}
 
 	// 3. Dev fallback: run `node dist/src/cli.js` from the source tree.
-	let cli_js = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+	let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 		.join("..")
-		.join("..")
-		.join("dist")
-		.join("src")
-		.join("cli.js");
+		.join("..");
+	let cli_js = project_root.join("dist").join("src").join("cli.js");
+	let loader = project_root.join("scripts").join("module-resolver.mjs");
 	let node = find_node().unwrap_or_else(|| "node".to_string());
 	log_file(&format!(
-		"resolve_pizza_command: dev fallback, node={}, cli_js={}",
+		"resolve_pizza_command: dev fallback, node={}, cli_js={}, loader={}",
 		node,
-		cli_js.display()
+		cli_js.display(),
+		loader.display()
 	));
 	(
 		node,
 		vec![
+			"--loader".to_string(),
+			loader.to_string_lossy().to_string(),
 			cli_js.to_string_lossy().to_string(),
 			"--mode".to_string(),
 			"rpc".to_string(),
@@ -1264,6 +1266,34 @@ pub async fn read_file(cwd: String, file_path: String) -> Result<String, String>
 		));
 	}
 	std::fs::read_to_string(&full).map_err(|e| format!("read_to_string: {e}"))
+}
+
+/// Fetch the skills.sh leaderboard HTML page via Rust (bypasses CORS).
+/// Returns the raw HTML so the frontend can parse skill links.
+#[tauri::command]
+pub async fn fetch_skills_sh() -> Result<String, String> {
+	let client = reqwest::Client::builder()
+		.user_agent("pizza-desktop/0.1")
+		.timeout(Duration::from_secs(15))
+		.build()
+		.map_err(|e| format!("HTTP client error: {e}"))?;
+
+	let res = client
+		.get("https://www.skills.sh/")
+		.send()
+		.await
+		.map_err(|e| format!("Fetch error: {e}"))?;
+
+	if !res.status().is_success() {
+		return Err(format!("skills.sh returned status {}", res.status()));
+	}
+
+	let html = res
+		.text()
+		.await
+		.map_err(|e| format!("Read body error: {e}"))?;
+
+	Ok(html)
 }
 
 #[cfg(test)]

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
 			bridge::list_dir,
 			bridge::read_file,
 			bridge::open_in_editor,
+			bridge::fetch_skills_sh,
 		])
 		.setup(|_app| {
 			#[cfg(debug_assertions)]

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -31,7 +31,7 @@
 			}
 		],
 		"security": {
-			"csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:*"
+			"csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* http://127.0.0.1:* https://skills.sh https://www.skills.sh"
 		}
 	},
 	"bundle": {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { PxlKitSurfaceProvider } from "@pxlkit/ui-kit";
 import Layout from "@/components/Layout";
 import ChatView from "@/views/ChatView";
 import SettingsView from "@/views/SettingsView";
+import PluginsView from "@/views/PluginsView";
 import { subscribeSidecarExit, subscribeEvents, initSidecar, sendCommandAwait, listWorkspaces } from "@/lib/transport";
 import { BrandIcon } from "@/components/BrandIcon";
 import type { RpcSessionState, WorkspaceMeta } from "@/lib/types";
@@ -309,6 +310,7 @@ function AppInner() {
 							}
 						/>
 						<Route path="/settings" element={<SettingsView state={state} />} />
+						<Route path="/plugins" element={<PluginsView />} />
 						<Route path="*" element={<Navigate to="/" replace />} />
 					</Route>
 			</Routes>

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Outlet } from "react-router-dom";
-import { Settings as SettingsIcon, Plus, Folder, MessageSquare, MoreHorizontal, Pin, FolderOpen, Trash2, PanelLeft } from "lucide-react";
+import { Settings as SettingsIcon, Plus, Folder, MessageSquare, MoreHorizontal, Pin, FolderOpen, Trash2, PanelLeft, Puzzle } from "lucide-react";
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -389,6 +389,30 @@ export default function Layout({
 						<Button tone="neutral" size="sm" iconLeft={<Plus className="h-3.5 w-3.5" />} onClick={() => onNewWorkspace?.()} className="w-full">{t("layout.newWorkspace")}</Button>
 					</div>
 				)}
+
+				{/* Plugins nav */}
+				<div className="border-t border-border px-3 pt-2 pb-1">
+					<NavLink
+						to="/plugins"
+						className={({ isActive }) => cn(
+							"flex w-full items-center gap-2 rounded-md border px-2 py-2 text-left transition-colors",
+							isActive
+								? "border-accent bg-accent/10"
+								: "border-transparent hover:bg-surface-2",
+						)}
+						title={t("plugins.title")}
+					>
+						<Puzzle className={cn("h-4 w-4 shrink-0 text-muted")} />
+						<div className="min-w-0 flex-1">
+							<div className="truncate font-mono text-xs font-bold uppercase tracking-wide text-fg">
+								{t("layout.plugins")}
+							</div>
+							<div className="truncate font-mono text-[10px] text-muted">
+								{t("layout.pluginsSubtitle")}
+							</div>
+						</div>
+					</NavLink>
+				</div>
 
 				<div className="border-t border-border px-3 py-3">
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -36,7 +36,9 @@
 		"timeJustNow": "just now",
 		"timeMinutesAgo": "{{count}}m ago",
 		"timeHoursAgo": "{{count}}h ago",
-		"timeDaysAgo": "{{count}}d ago"
+		"timeDaysAgo": "{{count}}d ago",
+		"plugins": "Plugins",
+		"pluginsSubtitle": "Skills · Extensions · MCP"
 	},
 	"chat": {
 		"newChat": "New Chat",
@@ -171,6 +173,43 @@
 	"theme": {
 		"switchToLight": "Switch to light",
 		"switchToDark": "Switch to dark"
+	},
+	"plugins": {
+		"title": "Plugins",
+		"description": "Manage skills, extensions, MCP tools, and integrations",
+		"loading": "Loading...",
+		"error": "Error: {{error}}",
+		"refresh": "Refresh",
+		"tabs": {
+			"skills": "Skills",
+			"extensions": "Extensions",
+			"mcp": "MCP",
+			"tools": "Tools"
+		},
+		"skills": {
+			"type": "Skill",
+			"search": "Search skills...",
+			"count": "{{count}} skill(s)",
+			"empty": "No skills found",
+			"emptyHint": "Skills will appear here when available.",
+			"view": "View",
+			"install": "Install",
+			"installed": "Installed",
+			"installedSection": "Installed Skills",
+			"directorySection": "Skill Directory"
+		},
+		"extensions": {
+			"comingSoon": "Extensions coming soon",
+			"comingSoonHint": "Extension management will be available here."
+		},
+		"mcp": {
+			"comingSoon": "MCP tools coming soon",
+			"comingSoonHint": "MCP server configuration will be available here."
+		},
+		"tools": {
+			"comingSoon": "Tools coming soon",
+			"comingSoonHint": "Custom tool management will be available here."
+		}
 	},
 	"settings": {
 		"title": "Settings",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -36,7 +36,9 @@
 		"timeJustNow": "刚刚",
 		"timeMinutesAgo": "{{count}}分钟前",
 		"timeHoursAgo": "{{count}}小时前",
-		"timeDaysAgo": "{{count}}天前"
+		"timeDaysAgo": "{{count}}天前",
+		"plugins": "插件",
+		"pluginsSubtitle": "技能 · 扩展 · MCP"
 	},
 	"chat": {
 		"newChat": "新对话",
@@ -171,6 +173,43 @@
 	"theme": {
 		"switchToLight": "切换到浅色",
 		"switchToDark": "切换到深色"
+	},
+	"plugins": {
+		"title": "插件",
+		"description": "管理技能、扩展、MCP 工具和集成",
+		"loading": "加载中...",
+		"error": "错误:{{error}}",
+		"refresh": "刷新",
+		"tabs": {
+			"skills": "技能",
+			"extensions": "扩展",
+			"mcp": "MCP",
+			"tools": "工具"
+		},
+		"skills": {
+			"type": "技能",
+			"search": "搜索技能...",
+			"count": "{{count}} 个技能",
+			"empty": "未找到技能",
+			"emptyHint": "可用技能将显示在这里。",
+			"view": "查看",
+			"install": "安装",
+			"installed": "已安装",
+			"installedSection": "已安装技能",
+			"directorySection": "技能目录"
+		},
+		"extensions": {
+			"comingSoon": "扩展即将推出",
+			"comingSoonHint": "扩展管理功能将在这里提供。"
+		},
+		"mcp": {
+			"comingSoon": "MCP 工具即将推出",
+			"comingSoonHint": "MCP 服务器配置将在这里提供。"
+		},
+		"tools": {
+			"comingSoon": "工具即将推出",
+			"comingSoonHint": "自定义工具管理将在这里提供。"
+		}
 	},
 	"settings": {
 		"title": "设置",

--- a/apps/web/src/lib/transport.ts
+++ b/apps/web/src/lib/transport.ts
@@ -274,6 +274,62 @@ export async function getSkills(): Promise<SkillInfo[]> {
 	}
 }
 
+// --- Skills.sh directory ---
+
+export interface SkillsShSkill {
+	id: string;
+	source: string;
+	slug: string;
+	name: string;
+	url: string;
+	installUrl?: string;
+	installs?: number;
+}
+
+/**
+ * Fetch skill directory from skills.sh by scraping the HTML leaderboard.
+ * The official API requires Vercel OIDC auth, but the HTML page contains
+ * all skill links rendered server-side.
+ */
+export async function fetchSkillsSh(): Promise<SkillsShSkill[]> {
+	try {
+		let html: string;
+		if (isTauri()) {
+			const core = await import("@tauri-apps/api/core");
+			html = await core.invoke<string>("fetch_skills_sh");
+		} else {
+			const res = await fetch("https://www.skills.sh/", {
+				headers: { Accept: "text/html" },
+			});
+			if (!res.ok) return [];
+			html = await res.text();
+		}
+		const seen = new Set<string>();
+		const skills: SkillsShSkill[] = [];
+		const linkRegex = /href="\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)"/g;
+		let match: RegExpExecArray | null;
+		while ((match = linkRegex.exec(html)) !== null) {
+			const link = "/" + match[1];
+			if (link.startsWith("/_next") || seen.has(link)) continue;
+			seen.add(link);
+			const parts = link.slice(1).split("/");
+			const source = parts.slice(0, -1).join("/");
+			const slug = parts[parts.length - 1];
+			skills.push({
+				id: `${source}/${slug}`,
+				source,
+				slug,
+				name: slug,
+				url: `https://www.skills.sh${link}`,
+				installUrl: `https://github.com/${source}`,
+			});
+		}
+		return skills;
+	} catch {
+		return [];
+	}
+}
+
 // --- Delete workspace (Tauri only) ---
 
 export async function deleteWorkspace(workspaceId: string): Promise<void> {

--- a/apps/web/src/views/PluginsView.tsx
+++ b/apps/web/src/views/PluginsView.tsx
@@ -1,0 +1,323 @@
+import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useLocation, useOutletContext } from "react-router-dom";
+import { PageHeader, Card, Badge, Button } from "@/components/ui";
+import { cn } from "@/lib/utils";
+import { fetchSkillsSh, getSkills, type SkillsShSkill, type SkillInfo } from "@/lib/transport";
+import { ArrowLeft, ArrowRight, Puzzle, BookOpen, Wrench, Server, Search, ExternalLink, Download, Check } from "lucide-react";
+import type { LayoutOutletContext } from "@/components/Layout";
+
+type PluginTab = "skills" | "extensions" | "mcp" | "tools";
+
+interface TabConfig {
+	key: PluginTab;
+	icon: typeof BookOpen;
+}
+
+const TABS: TabConfig[] = [
+	{ key: "skills", icon: BookOpen },
+	{ key: "extensions", icon: Puzzle },
+	{ key: "mcp", icon: Server },
+	{ key: "tools", icon: Wrench },
+];
+
+function InstalledSkillCard({ skill }: { skill: SkillInfo }) {
+	const { t } = useTranslation();
+	return (
+		<Card className="transition-colors hover:border-accent/40">
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0 flex-1">
+					<div className="flex items-center gap-2">
+						<BookOpen className="h-4 w-4 shrink-0 text-accent" />
+						<span className="truncate text-sm font-medium text-fg">{skill.name}</span>
+					</div>
+					{skill.description && (
+						<p className="mt-2 line-clamp-2 text-xs text-muted">{skill.description}</p>
+					)}
+					<div className="mt-3 flex items-center gap-2">
+						<Badge tone="success">{t("plugins.skills.installed")}</Badge>
+						<code className="font-mono text-[10px] text-muted">{skill.command}</code>
+					</div>
+				</div>
+				<Check className="h-4 w-4 shrink-0 text-success" />
+			</div>
+		</Card>
+	);
+}
+
+function DirectorySkillCard({ skill, installed }: { skill: SkillsShSkill; installed: boolean }) {
+	const { t } = useTranslation();
+	return (
+		<Card className="transition-colors hover:border-accent/40">
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0 flex-1">
+					<div className="flex items-center gap-2">
+						<BookOpen className="h-4 w-4 shrink-0 text-accent" />
+						<span className="truncate text-sm font-medium text-fg">{skill.name}</span>
+					</div>
+					<p className="mt-2 line-clamp-1 text-xs text-muted">{skill.source}</p>
+					<div className="mt-3 flex items-center gap-2">
+						{installed ? (
+							<Badge tone="success">{t("plugins.skills.installed")}</Badge>
+						) : (
+							<Badge tone="accent">{t("plugins.skills.type")}</Badge>
+						)}
+						<a
+							href={skill.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1 text-[10px] text-muted transition-colors hover:text-accent"
+						>
+							<ExternalLink className="h-3 w-3" />
+							{t("plugins.skills.view")}
+						</a>
+					</div>
+				</div>
+				{!installed && (
+					<a
+						href={skill.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="inline-flex shrink-0 items-center gap-1 rounded-md border border-border px-2 py-1 text-[10px] text-muted transition-colors hover:border-accent hover:text-accent"
+						title={t("plugins.skills.install")}
+					>
+						<Download className="h-3 w-3" />
+						{t("plugins.skills.install")}
+					</a>
+				)}
+			</div>
+		</Card>
+	);
+}
+
+function SkillsTab() {
+	const { t } = useTranslation();
+	const [dirSkills, setDirSkills] = useState<SkillsShSkill[]>([]);
+	const [installedSkills, setInstalledSkills] = useState<SkillInfo[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState("");
+	const [search, setSearch] = useState("");
+
+	const refresh = useCallback(async () => {
+		try {
+			setLoading(true);
+			setError("");
+			// Load both in parallel — local skills may fail if sidecar is down
+			const [dir, local] = await Promise.allSettled([
+				fetchSkillsSh(),
+				getSkills(),
+			]);
+			if (dir.status === "fulfilled") setDirSkills(dir.value);
+			if (local.status === "fulfilled") setInstalledSkills(local.value);
+			if (dir.status === "rejected" && local.status === "rejected") {
+				setError(dir.reason instanceof Error ? dir.reason.message : String(dir.reason));
+			}
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	const installedNames = new Set(installedSkills.map((s) => s.name));
+	const filteredDir = search.trim()
+		? dirSkills.filter(
+				(s) =>
+					s.name.toLowerCase().includes(search.toLowerCase()) ||
+					s.source.toLowerCase().includes(search.toLowerCase()) ||
+					s.slug.toLowerCase().includes(search.toLowerCase()),
+			)
+		: dirSkills;
+	const filteredLocal = search.trim()
+		? installedSkills.filter(
+				(s) =>
+					s.name.toLowerCase().includes(search.toLowerCase()) ||
+					s.description?.toLowerCase().includes(search.toLowerCase()),
+			)
+		: installedSkills;
+
+	if (loading) {
+		return (
+			<Card>
+				<div className="text-sm text-muted">{t("plugins.loading")}</div>
+			</Card>
+		);
+	}
+
+	if (error) {
+		return (
+			<Card>
+				<div className="text-sm text-danger">{t("plugins.error", { error })}</div>
+			</Card>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center gap-2">
+				<div className="relative flex-1">
+					<Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />
+					<input
+						type="text"
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						placeholder={t("plugins.skills.search")}
+						className="w-full rounded-md border border-border bg-surface px-9 py-2 font-mono text-xs text-fg placeholder:text-muted focus:border-accent focus:outline-none"
+					/>
+				</div>
+				<Button size="sm" tone="neutral" onClick={refresh}>
+					{t("plugins.refresh")}
+				</Button>
+			</div>
+
+				{filteredLocal.length > 0 && (
+				<>
+					<h2 className="mb-3 text-sm font-semibold text-fg">
+						{t("plugins.skills.installedSection")} ({filteredLocal.length})
+					</h2>
+					<div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+						{filteredLocal.map((skill) => (
+							<InstalledSkillCard key={skill.command} skill={skill} />
+						))}
+					</div>
+				</>
+			)}
+
+			<h2 className="mb-3 text-sm font-semibold text-fg">
+				{t("plugins.skills.directorySection")} ({filteredDir.length})
+			</h2>
+
+			{filteredDir.length === 0 ? (
+				<Card>
+					<div className="py-6 text-center">
+						<BookOpen className="mx-auto mb-2 h-8 w-8 text-muted/40" />
+						<p className="font-mono text-xs text-muted">{t("plugins.skills.empty")}</p>
+						<p className="mt-1 font-mono text-[10px] text-muted">{t("plugins.skills.emptyHint")}</p>
+					</div>
+				</Card>
+			) : (
+				<div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+					{filteredDir.map((skill) => (
+						<DirectorySkillCard
+							key={skill.id}
+							skill={skill}
+							installed={installedNames.has(skill.slug)}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function ComingSoonTab({ icon: Icon, title, description }: { icon: typeof BookOpen; title: string; description: string }) {
+	return (
+		<Card>
+			<div className="py-8 text-center">
+				<Icon className="mx-auto mb-3 h-10 w-10 text-muted/30" />
+				<p className="font-mono text-sm text-muted">{title}</p>
+				<p className="mt-2 font-mono text-xs text-muted/60">{description}</p>
+			</div>
+		</Card>
+	);
+}
+
+export default function PluginsView() {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const location = useLocation();
+	const { sidebarCollapsed } = useOutletContext<LayoutOutletContext>() ?? { sidebarCollapsed: false };
+	const [tab, setTab] = useState<PluginTab>("skills");
+
+	const histIdx = (window.history.state as { idx?: number } | null)?.idx ?? 0;
+	const canBack = histIdx > 0;
+	const canForward = histIdx > 0 && location.key !== "";
+
+	return (
+		<div className="flex h-full flex-col">
+			<div
+				data-tauri-drag-region
+				className={cn(
+					"flex h-11 shrink-0 items-center gap-1 border-b border-border bg-surface/80 pr-6 backdrop-blur transition-[padding] duration-150",
+					sidebarCollapsed ? "pl-[120px]" : "pl-6",
+				)}
+			>
+				<button
+					data-no-drag
+					type="button"
+					onClick={() => navigate(-1)}
+					disabled={!canBack}
+					className={cn(
+						"flex h-8 w-8 items-center justify-center rounded-lg transition-colors",
+						canBack ? "text-muted hover:bg-surface-2 hover:text-fg" : "text-muted/30",
+					)}
+					title={t("common.back")}
+				>
+					<ArrowLeft className="h-4 w-4" />
+				</button>
+				<button
+					data-no-drag
+					type="button"
+					onClick={() => navigate(1)}
+					disabled={!canForward}
+					className={cn(
+						"flex h-8 w-8 items-center justify-center rounded-lg transition-colors",
+						canForward ? "text-muted hover:bg-surface-2 hover:text-fg" : "text-muted/30",
+					)}
+					title={t("common.forward")}
+				>
+					<ArrowRight className="h-4 w-4" />
+				</button>
+			</div>
+
+			<div className="scrollbar-hide flex-1 overflow-y-auto">
+				<div className="mx-auto max-w-5xl px-10 pb-10 pt-10">
+					<PageHeader title={t("plugins.title")} description={t("plugins.description")} />
+
+					<div className="mb-6 flex gap-1 border-b border-border">
+						{TABS.map(({ key, icon: Icon }) => (
+							<button
+								key={key}
+								onClick={() => setTab(key)}
+								className={cn(
+									"flex items-center gap-1.5 px-4 py-2 text-sm font-medium transition-colors",
+									tab === key
+										? "border-b-2 border-accent text-accent"
+										: "text-muted hover:text-fg",
+								)}
+							>
+								<Icon className="h-3.5 w-3.5" />
+								{t(`plugins.tabs.${key}`)}
+							</button>
+						))}
+					</div>
+
+					{tab === "skills" && <SkillsTab />}
+					{tab === "extensions" && (
+						<ComingSoonTab
+							icon={Puzzle}
+							title={t("plugins.extensions.comingSoon")}
+							description={t("plugins.extensions.comingSoonHint")}
+						/>
+					)}
+					{tab === "mcp" && (
+						<ComingSoonTab
+							icon={Server}
+							title={t("plugins.mcp.comingSoon")}
+							description={t("plugins.mcp.comingSoonHint")}
+						/>
+					)}
+					{tab === "tools" && (
+						<ComingSoonTab
+							icon={Wrench}
+							title={t("plugins.tools.comingSoon")}
+							description={t("plugins.tools.comingSoonHint")}
+						/>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.1.8",
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-ai": "^0.80.6",
-				"@earendil-works/pi-tui": "^0.80.6",
+				"@earendil-works/pi-ai": "0.80.6",
+				"@earendil-works/pi-tui": "0.80.6",
 				"@mariozechner/jiti": "^2.6.2",
 				"@pizza/protocol": "file:./packages/protocol",
 				"@silvia-odwyer/photon-node": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
 	},
 	"dependencies": {
 		"@mariozechner/jiti": "^2.6.2",
-		"@earendil-works/pi-ai": "^0.80.6",
-		"@earendil-works/pi-tui": "^0.80.6",
+		"@earendil-works/pi-ai": "0.80.6",
+		"@earendil-works/pi-tui": "0.80.6",
 		"@silvia-odwyer/photon-node": "^0.3.4",
 		"@sinclair/typebox": "^0.34.41",
 		"ajv": "^8.17.1",

--- a/scripts/module-resolver.mjs
+++ b/scripts/module-resolver.mjs
@@ -1,0 +1,32 @@
+// ESM loader that redirects bare specifier resolution to the project root's node_modules.
+// This allows the sidecar (whose cwd is ~/.pizza/main) to find dependencies installed
+// in the pizza project directory during development.
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+
+export async function resolve(specifier, context, nextResolve) {
+	// Only intercept bare specifiers (not relative/absolute paths or URLs)
+	if (
+		specifier.startsWith("./") ||
+		specifier.startsWith("../") ||
+		specifier.startsWith("/") ||
+		specifier.startsWith("file:") ||
+		specifier.startsWith("data:") ||
+		specifier.startsWith("node:") ||
+		specifier.startsWith("#")
+	) {
+		return nextResolve(specifier, context);
+	}
+
+	// Try resolving from the project root first
+	try {
+		return await nextResolve(specifier, {
+			...context,
+			parentURL: pathToFileURL(projectRoot + "/").href,
+		});
+	} catch {
+		// Fall back to default resolution
+		return nextResolve(specifier, context);
+	}
+}


### PR DESCRIPTION
…isplay

- Add PluginsView with Skills/Extensions/MCP/Tools tabs
- Add Plugins nav item in sidebar below Workspaces
- Add fetchSkillsSh() to scrape skills.sh directory (via Rust proxy to bypass CORS)
- Add fetch_skills_sh Tauri command using reqwest
- Add ESM module-resolver.mjs loader for dev mode sidecar (fixes bare specifier resolution when cwd is ~/.pizza/main instead of project root)
- Update CSP to allow skills.sh connections
- Add i18n strings for plugins UI (en + zh-CN)

# Description

<!-- Thanks for opening a Pull Request, Describe Your PR Here -->



## Checklist

<!-- Before submitting your PR, there are a few things you can do to make sure it goes smoothly: -->

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/tomsun28/pizza/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number>
