### PR TITLE
fix(cli): preserve backslashes inside quotes in builtin command parsing

### DIFF
--- a/src/core/intent/classifier.ts
+++ b/src/core/intent/classifier.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IntentClassification, IntentCategory, IntentRisk } from "./types.js";
+import { splitShellWords } from "../shell-words.js";
 
 // ============================================================================
 // Classifier Configuration
@@ -419,47 +420,6 @@ function parseBuiltinInvocation(command: string): { command: "read" | "write" | 
 	}
 
 	return { command: builtin, path };
-}
-
-function splitShellWords(input: string): string[] {
-	const words: string[] = [];
-	let current = "";
-	let quote: "'" | "\"" | undefined;
-	let escaped = false;
-
-	for (const char of input) {
-		if (escaped) {
-			current += char;
-			escaped = false;
-			continue;
-		}
-		if (char === "\\") {
-			escaped = true;
-			continue;
-		}
-		if (quote) {
-			if (char === quote) {
-				quote = undefined;
-			} else {
-				current += char;
-			}
-			continue;
-		}
-		if (char === "'" || char === "\"") {
-			quote = char;
-			continue;
-		}
-		if (/\s/.test(char)) {
-			if (current) {
-				words.push(current);
-				current = "";
-			}
-			continue;
-		}
-		current += char;
-	}
-	if (current) words.push(current);
-	return words;
 }
 
 function getNonNullRedirectPath(command: string): string | undefined {

--- a/src/core/shell-words.ts
+++ b/src/core/shell-words.ts
@@ -1,0 +1,83 @@
+/**
+ * POSIX-aware shell word splitter shared by builtin command parsing and the
+ * intent classifier.
+ *
+ * Quoting semantics (POSIX shell):
+ *   - single quotes: every character is literal; backslash never escapes
+ *   - double quotes: backslash is special only before $ ` " \ and newline;
+ *     before any other char the backslash itself is kept literally
+ *   - unquoted: a backslash escapes the next character (a trailing backslash
+ *     is kept literally)
+ *
+ * Whitespace outside quotes separates words.
+ */
+export function splitShellWords(input: string): string[] {
+	const words: string[] = [];
+	let current = "";
+	// Active quote context: undefined (unquoted), "'" (single), or '"' (double).
+	let quote: "'" | '"' | undefined;
+
+	// Inside double quotes a backslash only escapes these characters; before
+	// any other char the backslash itself is kept literally. (String.fromCharCode
+	// is used for the newline entry to avoid escape-sequence ambiguity.)
+	const doubleEscapable = new Set(["$", "`", '"', "\\", String.fromCharCode(10)]);
+
+	for (let i = 0; i < input.length; i++) {
+		const char = input[i];
+		const next = input[i + 1];
+
+		if (quote === "'") {
+			// Single quote: everything is literal until the closing quote.
+			if (char === "'") {
+				quote = undefined;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+
+		if (quote === '"') {
+			// Double quote: backslash is special only before $ ` " \ and newline.
+			if (char === "\\" && next !== undefined && doubleEscapable.has(next)) {
+				current += next;
+				i++;
+			} else if (char === '"') {
+				quote = undefined;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+
+		// Unquoted.
+		if (char === "\\") {
+			if (next !== undefined) {
+				current += next;
+				i++;
+			} else {
+				// A trailing backslash is kept literally.
+				current += "\\";
+			}
+			continue;
+		}
+		if (char === "'" || char === '"') {
+			quote = char;
+			continue;
+		}
+		if (/\s/.test(char)) {
+			if (current.length > 0) {
+				words.push(current);
+				current = "";
+			}
+			continue;
+		}
+		current += char;
+	}
+
+	// An unterminated quote keeps whatever was collected (best-effort); a
+	// trailing backslash was already handled inside the loop.
+	if (current.length > 0) {
+		words.push(current);
+	}
+	return words;
+}

--- a/src/core/tools/builtin-commands.ts
+++ b/src/core/tools/builtin-commands.ts
@@ -21,6 +21,7 @@ import {
 } from "./edit-diff.js";
 import { annotateTextWithLineAnchors } from "./line-anchors.js";
 import { truncateHead } from "./truncate.js";
+import { splitShellWords } from "../shell-words.js";
 
 export interface BuiltinCommandResult {
 	stdout: string;
@@ -479,52 +480,6 @@ function parseOptionalInt(value: string | undefined): number | undefined {
 	if (value === undefined) return undefined;
 	const parsed = parseInt(value, 10);
 	return Number.isNaN(parsed) ? undefined : parsed;
-}
-
-function splitShellWords(input: string): string[] {
-	const words: string[] = [];
-	let current = "";
-	let quote: "'" | "\"" | undefined;
-	let escaped = false;
-
-	for (const char of input) {
-		if (escaped) {
-			current += char;
-			escaped = false;
-			continue;
-		}
-		if (char === "\\") {
-			escaped = true;
-			continue;
-		}
-		if (quote) {
-			if (char === quote) {
-				quote = undefined;
-			} else {
-				current += char;
-			}
-			continue;
-		}
-		if (char === "'" || char === "\"") {
-			quote = char;
-			continue;
-		}
-		if (/\s/.test(char)) {
-			if (current.length > 0) {
-				words.push(current);
-				current = "";
-			}
-			continue;
-		}
-		current += char;
-	}
-	if (escaped) {
-		current += "\\";
-	}
-	if (current.length > 0) {
-		words.push(current);
-	}
-	return words;
 }
 
 function isHelpRequest(args: string[]): boolean {

--- a/test/builtin-heredoc.test.ts
+++ b/test/builtin-heredoc.test.ts
@@ -86,6 +86,32 @@ describe("parseBuiltinCommand (heredoc integration)", () => {
 		expect(result.heredoc).toBeUndefined();
 	});
 });
+describe("parseBuiltinCommand (backslash in quoted write content)", () => {
+	it("preserves a literal backslash inside double quotes", () => {
+		// Regression: backslash was dropped before the quote check, so "a\nb"
+		// (4 chars) became "anb" (3 chars). POSIX keeps the backslash here.
+		const result = parseBuiltinCommand('_write f.txt "a' + String.fromCharCode(0x5c) + 'nb"');
+		expect(result.command).toBe("_write");
+		expect(result.args).toEqual(["f.txt", "a" + String.fromCharCode(0x5c) + "nb"]);
+	});
+
+	it("preserves a literal backslash inside single quotes", () => {
+		// Single quotes keep everything literally, including the backslash.
+		const result = parseBuiltinCommand("_write f.txt 'a" + String.fromCharCode(0x5c) + "nb'");
+		expect(result.args).toEqual(["f.txt", "a" + String.fromCharCode(0x5c) + "nb"]);
+	});
+
+	it("still treats a backslash as an escape when unquoted", () => {
+		// Unquoted, backslash escapes the next char (shell semantics).
+		const result = parseBuiltinCommand("_write f.txt a" + String.fromCharCode(0x5c) + "nb");
+		expect(result.args).toEqual(["f.txt", "anb"]);
+	});
+
+	it("escapes a double-quote inside double quotes (\"a\\\"b\" -> a\"b)", () => {
+		const result = parseBuiltinCommand('_write f.txt "a' + String.fromCharCode(0x5c) + '"b"');
+		expect(result.args).toEqual(["f.txt", 'a"b']);
+	});
+});
 
 /**
  * End-to-end routing: a quoted-heredoc write must be routed as a builtin


### PR DESCRIPTION
## Problem

`_write` (and other builtin commands) corrupted content containing backslashes. `_write f.txt "a\nb"` and `_write f.txt 'a\nb'` both wrote `anb` (3 bytes) instead of `a\nb` (4 bytes). Any content with a backslash — code, file paths, regex, LaTeX — had backslashes silently dropped.

## Root cause

`splitShellWords` ran the backslash-escape check **before** the quote check, so backslashes were treated as escapes even inside quotes:

```js
if (char === "\\") { escaped = true; continue; }   // ran first
if (quote) { ... }                                   // never reached for backslash
```

The same buggy copy was duplicated in `builtin-commands.ts` and `classifier.ts`.

Byte-level repro confirmed: file got `61 6e 62` (`anb`) instead of `61 5c 6e 62` (`a\nb`).

## Fix

Implement correct POSIX shell quoting semantics, and deduplicate into a single shared module `src/core/shell-words.ts`:

- **Single quotes** — everything literal, backslash never escapes
- **Double quotes** — backslash is special only before `` $ ` `` `"` `\` and newline; otherwise kept literally
- **Unquoted** — backslash escapes the next character (unchanged)

Both `builtin-commands.ts` and `classifier.ts` now import the shared function instead of each keeping a private buggy copy.

## Verification

- Byte-level end-to-end: `a\nb` correctly preserved as `61 5c 6e 62`
- Heredoc, quoted newlines/spaces unaffected
- Added 4 regression tests (`backslash in quoted write content`)
- Existing suite green: 136 tests across 6 related files; `intent-classifier` 21 tests; `tsc` clean

## Test plan

- [ ] `_write f.txt "a\nb"` writes `a\nb` (with backslash)
- [ ] `_write f.txt 'a\nb'` writes `a\nb`
- [ ] `_edit --old "foo bar" --new "baz qux"` still splits quoted args correctly
- [ ] `npx vitest run` passes