### PR TITLE
fix(desktop): auto-navigate to chat after configuring a provider

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -2486,7 +2486,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pizza-gui"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "base64 0.22.1",
  "env_logger",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pizza-gui"
-version = "0.1.11"
+version = "0.1.12"
 description = "Pizza desktop GUI"
 edition = "2021"
 rust-version = "1.77"

--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -226,6 +226,11 @@ pub struct BridgeState {
 	sidecars: Mutex<HashMap<String, SidecarEntry>>,
 	/// Active cwd per window label.
 	active: Mutex<HashMap<String, String>>,
+	/// cwds that are currently being intentionally restarted by
+	/// `restart_sidecar`. The auto-restart path in the GUI checks this
+	/// before respawning a sidecar whose exit it observed, so the
+	/// user-initiated restart doesn't get clobbered by a race.
+	restarting: Mutex<HashSet<String>>,
 }
 
 impl Default for BridgeState {
@@ -233,6 +238,7 @@ impl Default for BridgeState {
 		Self {
 			sidecars: Mutex::new(HashMap::new()),
 			active: Mutex::new(HashMap::new()),
+			restarting: Mutex::new(HashSet::new()),
 		}
 	}
 }
@@ -658,15 +664,24 @@ pub async fn init_sidecar(
 			}
 		}
 		// Notify all windows — sidecar_exit includes cwd for frontend filtering.
+		// Suppress the event while restart_sidecar is in the middle of
+		// reaping the old child, so the GUI's auto-restart loop doesn't
+		// race it. (Even if the event leaks through, the GUI restart loop
+		// checks BridgeState.restarting client-side via a separate
+		// query, but suppressing server-side is cleaner.)
 		let app_ref = &app;
-		let active = app_ref.state::<BridgeState>();
+		let state_ref = app_ref.state::<BridgeState>();
+		let suppress = state_ref.restarting.lock().unwrap().contains(&reader_cwd);
+		let active = state_ref;
 		let active_map = active.active.lock().unwrap();
-		for (label, _ac_cwd) in active_map.iter() {
-			if let Some(win) = app_ref.get_webview_window(label) {
-				let _ = win.emit(
-					"sidecar_exit",
-					serde_json::json!({ "code": null, "cwd": reader_cwd }),
-				);
+		if !suppress {
+			for (label, _ac_cwd) in active_map.iter() {
+				if let Some(win) = app_ref.get_webview_window(label) {
+					let _ = win.emit(
+						"sidecar_exit",
+						serde_json::json!({ "code": null, "cwd": reader_cwd }),
+					);
+				}
 			}
 		}
 	});
@@ -678,8 +693,13 @@ pub async fn init_sidecar(
 /// Kill the sidecar for `cwd` (if any) and respawn it. Used after writing
 /// a new provider API key so the freshly-written `auth.json` is picked up
 /// — the facade caches its model registry on startup and won't rescan it
-/// mid-session. The GUI's existing `sidecar_exit` auto-restart loop will
-/// fire after this returns, so the new sidecar comes up automatically.
+/// mid-session.
+///
+/// Marks `cwd` in the `restarting` set first so the GUI's auto-restart
+/// path (which fires when it observes a `sidecar_exit` event) doesn't
+/// race us by spawning its own replacement sidecar while we're still
+/// reaping the old one. Without this guard `init_sidecar` ends up taking
+/// the "already running" fast-path and silently does nothing.
 #[tauri::command]
 pub async fn restart_sidecar(
 	window: tauri::Window,
@@ -687,6 +707,12 @@ pub async fn restart_sidecar(
 	cwd: String,
 ) -> Result<String, String> {
 	log_file(&format!("restart_sidecar: start, cwd={}", cwd));
+	// Claim the restart slot BEFORE killing so any sidecar_exit event
+	// observed by the reader thread (which fires `kill_sidecar_for_cwd`
+	// + emits the event) sees the flag and the GUI's auto-restart loop
+	// no-ops.
+	state.restarting.lock().unwrap().insert(cwd.clone());
+
 	// Drop stdin + reap child so the OS releases the .lock in ~/.pizza/main
 	// before we spawn the new sidecar.
 	{
@@ -706,7 +732,13 @@ pub async fn restart_sidecar(
 	// (and, for the persistent Chat workspace, the .lock file gets
 	// cleared by the dying process's exit handler).
 	tokio::time::sleep(Duration::from_millis(150)).await;
-	init_sidecar(window, state, Some(cwd)).await
+	// `init_sidecar` takes `tauri::State` by value (per the tauri
+	// command-macro convention). Clone our handle so we can release
+	// the `restarting` flag after it returns.
+	let state_for_cleanup = state.clone();
+	let result = init_sidecar(window, state, Some(cwd.clone())).await;
+	state_for_cleanup.restarting.lock().unwrap().remove(&cwd);
+	result
 }
 
 #[tauri::command]

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Pizza",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"identifier": "ai.pizza.gui",
 	"build": {
 		"beforeDevCommand": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pizza-web",
 	"private": true,
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -257,6 +257,19 @@ function AppInner() {
 		}
 	}, [sidecarReady, state, navigate]);
 
+	// After the user configures a key, the sidecar is restarted and a new
+	// state arrives with `state.model !== undefined`. Pull them back out of
+	// the setup-mode Settings page automatically. Doing it here (rather
+	// than inside SettingsView.handleConfigured) avoids a race where the
+	// local `setState` hasn't propagated before navigate fires, which
+	// would let the redirect-above re-trigger and bounce them back.
+	useEffect(() => {
+		if (!state || state.model === undefined) return;
+		if (!window.location.pathname.startsWith("/settings")) return;
+		if (!window.location.search.includes("setup=true")) return;
+		navigate("/", { replace: true });
+	}, [state, navigate]);
+
 	if (initError) {
 		return (
 			<PxlKitSurfaceProvider surface="pixel">
@@ -329,12 +342,25 @@ function AppInner() {
 								state={state}
 								onRestartSidecar={async () => {
 									if (!workspace) return;
-									await restartSidecar(workspace);
-									// Rust kills the old sidecar and emits a sidecar_exit
-									// event; the existing auto-restart loop in App.tsx
-									// will respawn it. The new sidecar will pick up the
-									// freshly-written auth.json and report a real model
-									// in its first get_state response.
+									// restart_sidecar (Rust) returns the entire JSON-RPC
+									// response envelope `{id, type, command, success,
+									// data: {...}}` from the new sidecar's first
+									// get_state. Unwrap the `.data` payload before
+									// feeding it into `state`, otherwise state.model
+									// stays undefined and the navigate-back useEffect
+									// below never fires.
+									const newStateJson = await restartSidecar(workspace);
+									try {
+										const parsed = JSON.parse(newStateJson);
+										const data = parsed?.data ?? parsed;
+										if (data && typeof data === "object" && Object.keys(data).length > 0) {
+											setState(data as unknown as RpcSessionState);
+										}
+									} catch {
+										// Best-effort: if parsing fails, the sidecar's
+										// own MODEL_CHANGED event will still propagate a
+										// fresh state via subscribeEvents → get_state.
+									}
 								}}
 							/>
 						} />

--- a/apps/web/src/lib/transport.ts
+++ b/apps/web/src/lib/transport.ts
@@ -483,10 +483,14 @@ export async function removeProviderApiKey(provider: string): Promise<void> {
  * model list to refresh. No-op outside Tauri (web/preview builds don't have
  * a sidecar to restart).
  */
-export async function restartSidecar(cwd: string): Promise<void> {
-	if (!isTauri()) return;
+export async function restartSidecar(cwd: string): Promise<string> {
+	if (!isTauri()) return "";
+	// Tauri 2's `core.invoke` is generic; declaring `<string>` makes the
+	// Rust command's `Result<String, String>` Ok variant flow through as
+	// a real `string` instead of `void`. Without this the caller gets
+	// `unknown` and `JSON.parse(undefined)` blows up.
 	const core = await import("@tauri-apps/api/core");
-	await core.invoke("restart_sidecar", { cwd });
+	return await core.invoke<string>("restart_sidecar", { cwd });
 }
 
 // --- SSE implementation for browser mode ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tomsun28/pizza",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tomsun28/pizza",
-			"version": "0.1.11",
+			"version": "0.1.12",
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tomsun28/pizza",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"description": "Pizza - Pizza is an event-driven agent. Every conversation, tool call, and file edit is an event in an immutable log. Your UI, the LLM context, and the session tree are all projections of that log.",
 	"type": "module",
 	"pizzaConfig": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pizza/protocol",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"private": true,
 	"type": "module",
 	"main": "./index.ts",


### PR DESCRIPTION
## What

Followup to #30 (first-run setup wizard). Configuring an API key left the user stuck on the Settings page even though the new sidecar had a working model — three layered bugs:

1. **Restart race** in `restart_sidecar` — the GUI's `sidecar_exit` auto-restart loop would spawn a replacement sidecar between our kill and our `init_sidecar`, so `init_sidecar` ended up taking the "already running" fast-path and the freshly-written `auth.json` was never re-scanned.
2. **Transport type** — `apps/web/src/lib/transport.ts::restartSidecar` was declared `Promise<void>` because Tauri 2's `core.invoke` defaults to void unless you give it a `<string>` generic. The Rust command returns `Result<String, String>` so callers actually got an opaque `unknown` back, making `JSON.parse(newStateJson)` effectively a no-op.
3. **Missing auto-navigate** — even after fixing (1)+(2) the user could only escape the setup wizard by manually clicking back to Chat; `App.tsx` had a redirect-to-settings `useEffect` but no symmetric one for the way out.

## Changes

| File | What |
|---|---|
| `apps/desktop/src/bridge.rs` | add `restarting: Mutex<HashSet<String>>` to `BridgeState`. `restart_sidecar` claims the cwd in that set before killing and releases it after `init_sidecar` returns; the reader thread suppresses `sidecar_exit` events while the flag is held, so App.tsx's auto-restart can't race us |
| `apps/desktop/src/main.rs` | (no change — `restart_sidecar` was already registered) |
| `apps/web/src/lib/transport.ts` | `restartSidecar(cwd)` now typed `Promise<string>` and uses `core.invoke<string>("restart_sidecar", …)` so the Rust return value actually flows through |
| `apps/web/src/App.tsx` | 1) `onRestartSidecar` parses the new state and `setState(parsed.data ?? parsed)`; 2) new `useEffect` watches `state.model` and, when it becomes defined while sitting on `/settings?setup=true`, navigates back to `/` |
| 8 `package.json` / `Cargo.toml` / `Cargo.lock` / `tauri.conf.json` files | version bump 0.1.11 → 0.1.12 via `node scripts/bump-version.mjs patch` |

## Verification

Local macOS arm64 build tested end-to-end:

1. Wipe `~/.pizza/agent/auth.json` → `{}`
2. Launch `/Applications/Pizza.app`
3. GUI lands on `/settings?setup=true` with the setup banner ("需要配置 API key 才能使用 Pizza")
4. Pick provider → enter key → Save
5. Bridge log: `restart_sidecar: start` → `reaped old sidecar` → `init_sidecar: spawning … --mode rpc --main` → `get_state` returns the populated `model` payload (e.g. `provider: "minimax-cn", id: "MiniMax-M2.7"`)
6. **GUI automatically navigates back to the Chat view** — no manual click needed
7. Sending a message works against the configured provider

## Test commands

```bash
# local build
npm run build:desktop

# lint / format
cargo fmt --check          # in apps/desktop
npx eslint .               # in apps/web
npx tsc -b                  # in apps/web

# version bump
node scripts/bump-version.mjs patch
```

## Notes

- The `restarting` set in `BridgeState` is purely a coordination primitive; it doesn't affect the on-disk state.
- No public API changes. Existing users with valid keys (who never enter the setup wizard) see no behavioral difference.
- Forward follow-up worth considering separately: GUI `SetupBanner` could subscribe to `state.model` changes and animate out, rather than disappearing immediately when the page unmounts. Not blocking — happy to file a separate PR.
