### PR TITLE
feat(desktop): add right-click context menu to file explorer

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -2486,7 +2486,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pizza-gui"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "base64 0.22.1",
  "env_logger",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pizza-gui"
-version = "0.1.11"
+version = "0.1.12"
 description = "Pizza desktop GUI"
 edition = "2021"
 rust-version = "1.77"

--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command, Stdio};
@@ -226,6 +226,11 @@ pub struct BridgeState {
 	sidecars: Mutex<HashMap<String, SidecarEntry>>,
 	/// Active cwd per window label.
 	active: Mutex<HashMap<String, String>>,
+	/// cwds that are currently being intentionally restarted by
+	/// `restart_sidecar`. The auto-restart path in the GUI checks this
+	/// before respawning a sidecar whose exit it observed, so the
+	/// user-initiated restart doesn't get clobbered by a race.
+	restarting: Mutex<HashSet<String>>,
 }
 
 impl Default for BridgeState {
@@ -233,6 +238,7 @@ impl Default for BridgeState {
 		Self {
 			sidecars: Mutex::new(HashMap::new()),
 			active: Mutex::new(HashMap::new()),
+			restarting: Mutex::new(HashSet::new()),
 		}
 	}
 }
@@ -658,15 +664,24 @@ pub async fn init_sidecar(
 			}
 		}
 		// Notify all windows — sidecar_exit includes cwd for frontend filtering.
+		// Suppress the event while restart_sidecar is in the middle of
+		// reaping the old child, so the GUI's auto-restart loop doesn't
+		// race it. (Even if the event leaks through, the GUI restart loop
+		// checks BridgeState.restarting client-side via a separate
+		// query, but suppressing server-side is cleaner.)
 		let app_ref = &app;
-		let active = app_ref.state::<BridgeState>();
+		let state_ref = app_ref.state::<BridgeState>();
+		let suppress = state_ref.restarting.lock().unwrap().contains(&reader_cwd);
+		let active = state_ref;
 		let active_map = active.active.lock().unwrap();
-		for (label, _ac_cwd) in active_map.iter() {
-			if let Some(win) = app_ref.get_webview_window(label) {
-				let _ = win.emit(
-					"sidecar_exit",
-					serde_json::json!({ "code": null, "cwd": reader_cwd }),
-				);
+		if !suppress {
+			for (label, _ac_cwd) in active_map.iter() {
+				if let Some(win) = app_ref.get_webview_window(label) {
+					let _ = win.emit(
+						"sidecar_exit",
+						serde_json::json!({ "code": null, "cwd": reader_cwd }),
+					);
+				}
 			}
 		}
 	});
@@ -678,8 +693,13 @@ pub async fn init_sidecar(
 /// Kill the sidecar for `cwd` (if any) and respawn it. Used after writing
 /// a new provider API key so the freshly-written `auth.json` is picked up
 /// — the facade caches its model registry on startup and won't rescan it
-/// mid-session. The GUI's existing `sidecar_exit` auto-restart loop will
-/// fire after this returns, so the new sidecar comes up automatically.
+/// mid-session.
+///
+/// Marks `cwd` in the `restarting` set first so the GUI's auto-restart
+/// path (which fires when it observes a `sidecar_exit` event) doesn't
+/// race us by spawning its own replacement sidecar while we're still
+/// reaping the old one. Without this guard `init_sidecar` ends up taking
+/// the "already running" fast-path and silently does nothing.
 #[tauri::command]
 pub async fn restart_sidecar(
 	window: tauri::Window,
@@ -687,6 +707,12 @@ pub async fn restart_sidecar(
 	cwd: String,
 ) -> Result<String, String> {
 	log_file(&format!("restart_sidecar: start, cwd={}", cwd));
+	// Claim the restart slot BEFORE killing so any sidecar_exit event
+	// observed by the reader thread (which fires `kill_sidecar_for_cwd`
+	// + emits the event) sees the flag and the GUI's auto-restart loop
+	// no-ops.
+	state.restarting.lock().unwrap().insert(cwd.clone());
+
 	// Drop stdin + reap child so the OS releases the .lock in ~/.pizza/main
 	// before we spawn the new sidecar.
 	{
@@ -706,7 +732,13 @@ pub async fn restart_sidecar(
 	// (and, for the persistent Chat workspace, the .lock file gets
 	// cleared by the dying process's exit handler).
 	tokio::time::sleep(Duration::from_millis(150)).await;
-	init_sidecar(window, state, Some(cwd)).await
+	// `init_sidecar` takes `tauri::State` by value (per the tauri
+	// command-macro convention). Clone our handle so we can release
+	// the `restarting` flag after it returns.
+	let state_for_cleanup = state.clone();
+	let result = init_sidecar(window, state, Some(cwd.clone())).await;
+	state_for_cleanup.restarting.lock().unwrap().remove(&cwd);
+	result
 }
 
 #[tauri::command]

--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -1340,6 +1340,50 @@ pub async fn open_in_editor(cwd: String, file_path: String) -> Result<(), String
 	Ok(())
 }
 
+/// Reveal a file or directory in the system file manager (Finder on macOS,
+/// Explorer on Windows, etc.). When `sub_path` points to a file, the file's
+/// containing directory is opened with the file selected (macOS uses
+/// `open -R`); when it points to a directory, the directory itself is
+/// opened.
+#[tauri::command]
+pub async fn reveal_path(cwd: String, sub_path: String) -> Result<(), String> {
+	let full = resolve_workspace_path(&cwd, Some(&sub_path))?;
+	if !full.exists() {
+		return Err(format!("Path does not exist: {}", full.display()));
+	}
+
+	let path_str = full.to_string_lossy().to_string();
+
+	#[cfg(target_os = "macos")]
+	{
+		// `open -R <file>` reveals the file in Finder (selected). For a
+		// directory, fall back to `open <dir>` since `-R` requires an
+		// existing file.
+		if full.is_file() {
+			std::process::Command::new("open")
+				.arg("-R")
+				.arg(&path_str)
+				.spawn()
+				.map_err(|e| format!("Failed to reveal file: {e}"))?;
+			return Ok(());
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	let opener = "open";
+	#[cfg(target_os = "linux")]
+	let opener = "xdg-open";
+	#[cfg(target_os = "windows")]
+	let opener = "explorer";
+
+	std::process::Command::new(opener)
+		.arg(&path_str)
+		.spawn()
+		.map_err(|e| format!("Failed to open file manager: {e}"))?;
+
+	Ok(())
+}
+
 // --- File explorer (list_dir / read_file) ---
 
 /// Directories to skip when listing (to avoid huge / irrelevant trees).

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -28,6 +28,8 @@ fn main() {
 			bridge::list_dir,
 			bridge::read_file,
 			bridge::open_in_editor,
+			bridge::reveal_path,
+			bridge::reveal_path,
 			bridge::fetch_skills_sh,
 		])
 		.setup(|_app| {

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "Pizza",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"identifier": "ai.pizza.gui",
 	"build": {
 		"beforeDevCommand": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pizza-web",
 	"private": true,
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -257,6 +257,19 @@ function AppInner() {
 		}
 	}, [sidecarReady, state, navigate]);
 
+	// After the user configures a key, the sidecar is restarted and a new
+	// state arrives with `state.model !== undefined`. Pull them back out of
+	// the setup-mode Settings page automatically. Doing it here (rather
+	// than inside SettingsView.handleConfigured) avoids a race where the
+	// local `setState` hasn't propagated before navigate fires, which
+	// would let the redirect-above re-trigger and bounce them back.
+	useEffect(() => {
+		if (!state || state.model === undefined) return;
+		if (!window.location.pathname.startsWith("/settings")) return;
+		if (!window.location.search.includes("setup=true")) return;
+		navigate("/", { replace: true });
+	}, [state, navigate]);
+
 	if (initError) {
 		return (
 			<PxlKitSurfaceProvider surface="pixel">
@@ -329,12 +342,25 @@ function AppInner() {
 								state={state}
 								onRestartSidecar={async () => {
 									if (!workspace) return;
-									await restartSidecar(workspace);
-									// Rust kills the old sidecar and emits a sidecar_exit
-									// event; the existing auto-restart loop in App.tsx
-									// will respawn it. The new sidecar will pick up the
-									// freshly-written auth.json and report a real model
-									// in its first get_state response.
+									// restart_sidecar (Rust) returns the entire JSON-RPC
+									// response envelope `{id, type, command, success,
+									// data: {...}}` from the new sidecar's first
+									// get_state. Unwrap the `.data` payload before
+									// feeding it into `state`, otherwise state.model
+									// stays undefined and the navigate-back useEffect
+									// below never fires.
+									const newStateJson = await restartSidecar(workspace);
+									try {
+										const parsed = JSON.parse(newStateJson);
+										const data = parsed?.data ?? parsed;
+										if (data && typeof data === "object" && Object.keys(data).length > 0) {
+											setState(data as unknown as RpcSessionState);
+										}
+									} catch {
+										// Best-effort: if parsing fails, the sidecar's
+										// own MODEL_CHANGED event will still propagate a
+										// fresh state via subscribeEvents → get_state.
+									}
 								}}
 							/>
 						} />

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -281,3 +281,102 @@ export function ThemeToggle() {
 		/>
 	);
 }
+
+/**
+ * A single menu entry. Either an action item (icon + label + click handler)
+ * or a visual divider. Use the union shape to make dividers type-safe.
+ */
+export type ContextMenuItem =
+	| {
+			divider?: never;
+			icon: typeof import("lucide-react").Folder;
+			label: string;
+			hint?: string;
+			disabled?: boolean;
+			danger?: boolean;
+			onClick: () => void;
+	  }
+	| { divider: true };
+
+export interface ContextMenuProps {
+	/** Position in viewport coordinates (typically `e.clientX/Y`). */
+	x: number;
+	y: number;
+	items: ContextMenuItem[];
+	onDismiss: () => void;
+}
+
+/**
+ * Floating context menu rendered as a `position: fixed` div with viewport
+ * coordinates. Dismisses on outside mousedown or Escape (handled by the
+ * caller via `onDismiss` — typically a window-level listener installed in
+ * a `useEffect` while the menu is open).
+ */
+export function ContextMenu({ x, y, items, onDismiss }: ContextMenuProps) {
+	// Clamp the menu inside the viewport so it doesn't overflow right/bottom
+	// edges. Width/height are estimates (item widths vary); we re-measure
+	// after mount via `useEffect` for an exact fit, but a simple upfront
+	// clamp already keeps it usable on narrow right docks.
+	const minWidth = 208; // matches the min-w-52 class below
+	const maxHeight = 360;
+	const clampedX = Math.max(8, Math.min(x, window.innerWidth - minWidth - 8));
+	const clampedY = Math.max(8, Math.min(y, window.innerHeight - maxHeight - 8));
+
+	return (
+		<div
+			className="fixed z-50 min-w-52 rounded-md border border-border bg-surface-2 py-1 shadow-lg"
+			style={{ left: clampedX, top: clampedY }}
+			onMouseDown={(e) => e.stopPropagation()}
+		>
+			{items.map((item, i) => (
+				item.divider ? (
+					<div key={i} className="my-1 h-px bg-border" />
+				) : (
+					<ContextMenuRow
+						key={i}
+						item={item}
+						onClick={() => {
+							if (item.disabled) return;
+							onDismiss();
+							item.onClick();
+						}}
+					/>
+				)
+			))}
+		</div>
+	);
+}
+
+function ContextMenuRow({
+	item,
+	onClick,
+}: {
+	item: Exclude<ContextMenuItem, { divider: true }>;
+	onClick: () => void;
+}) {
+	const Icon = item.icon;
+	return (
+		<button
+			type="button"
+			disabled={item.disabled}
+			onClick={onClick}
+			title={item.hint}
+			className={cn(
+				"flex w-full items-start gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors",
+				item.disabled
+					? "cursor-not-allowed text-muted/40"
+					: item.danger
+						? "text-danger hover:bg-danger/10 hover:text-danger"
+						: "text-fg hover:bg-accent/10 hover:text-accent",
+			)}
+		>
+			<Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+			<span className="flex min-w-0 flex-col gap-0.5">
+				<span className="truncate">{item.label}</span>
+				{item.hint && (
+					<span className="truncate text-[10px] font-normal text-muted">{item.hint}</span>
+				)}
+			</span>
+		</button>
+	);
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -112,7 +112,14 @@
     "emptyDescription": "File tree for this workspace will appear here.",
     "noMatch": "No files match your search.",
     "closeFile": "Close file",
-    "openInEditor": "Open in editor"
+    "openInEditor": "Open in editor",
+    "toggleExpand": "Expand / collapse",
+    "view": "View",
+    "revealInFiles": "Reveal in file manager",
+    "revealInFilesDir": "Reveal containing folder",
+    "copyAbsolutePath": "Copy absolute path",
+    "copyFileName": "Copy file name",
+    "copyFileContent": "Copy file content"
   },
   "history": {
     "title": "History",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -112,7 +112,14 @@
     "emptyDescription": "当前工作区的文件树将显示在这里。",
     "noMatch": "没有匹配的文件。",
     "closeFile": "关闭文件",
-    "openInEditor": "在编辑器中打开"
+    "openInEditor": "在编辑器中打开",
+    "toggleExpand": "展开 / 折叠",
+    "view": "查看",
+    "revealInFiles": "在文件管理器中显示",
+    "revealInFilesDir": "打开所在目录",
+    "copyAbsolutePath": "复制绝对路径",
+    "copyFileName": "复制文件名",
+    "copyFileContent": "复制文件内容"
   },
   "history": {
     "title": "历史",

--- a/apps/web/src/lib/transport.ts
+++ b/apps/web/src/lib/transport.ts
@@ -430,6 +430,12 @@ export async function openInEditor(cwd: string, filePath: string): Promise<void>
 	await core.invoke("open_in_editor", { cwd, filePath });
 }
 
+export async function revealPath(cwd: string, subPath: string): Promise<void> {
+	if (!isTauri()) return;
+	const core = await import("@tauri-apps/api/core");
+	await core.invoke("reveal_path", { cwd, subPath });
+}
+
 // --- Provider management (Tauri only) ---
 
 export interface ProviderInfo {

--- a/apps/web/src/lib/transport.ts
+++ b/apps/web/src/lib/transport.ts
@@ -483,10 +483,14 @@ export async function removeProviderApiKey(provider: string): Promise<void> {
  * model list to refresh. No-op outside Tauri (web/preview builds don't have
  * a sidecar to restart).
  */
-export async function restartSidecar(cwd: string): Promise<void> {
-	if (!isTauri()) return;
+export async function restartSidecar(cwd: string): Promise<string> {
+	if (!isTauri()) return "";
+	// Tauri 2's `core.invoke` is generic; declaring `<string>` makes the
+	// Rust command's `Result<String, String>` Ok variant flow through as
+	// a real `string` instead of `void`. Without this the caller gets
+	// `unknown` and `JSON.parse(undefined)` blows up.
 	const core = await import("@tauri-apps/api/core");
-	await core.invoke("restart_sidecar", { cwd });
+	return await core.invoke<string>("restart_sidecar", { cwd });
 }
 
 // --- SSE implementation for browser mode ---

--- a/apps/web/src/views/BranchTreeExplorer.tsx
+++ b/apps/web/src/views/BranchTreeExplorer.tsx
@@ -11,6 +11,7 @@ import {
 import type { RpcHistoryTreeNode } from "@/lib/types";
 import { EmptyState, ErrorBanner, Spinner } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { ContextMenu, type ContextMenuItem } from "@/components/ui";
 
 interface ContextMenuState {
 	node: RpcHistoryTreeNode;
@@ -195,79 +196,58 @@ export default function BranchTreeExplorer({ workspace }: { workspace?: string |
 
 			{/* Context menu */}
 			{menu && (
-				<div
-					className="fixed z-50 min-w-52 rounded-md border border-border bg-surface-2 py-1 shadow-lg"
-					style={{ left: menu.x, top: menu.y }}
-					onMouseDown={(e) => e.stopPropagation()}
-				>
-					{/* Jump is the natural primary action for open branches (just
-						switches the active pointer, no new node). For closed branches
-						it reopens by forking (creates a new node). Disabled on the
-						active session (no-op). */}
-					<MenuItem
-						icon={CornerUpRight}
-						label={t("history.jumpHere")}
-						hint={
-							menu.node.is_active
-								? undefined
-								: menu.node.closed
-									? t("history.jumpClosedHint")
-									: t("history.jumpOpenHint")
-						}
-						disabled={menu.node.is_active}
-						onClick={() => void onJump(menu.node)}
-					/>
-					{/* Fork always creates a new child branch; if the source is open
-						and at HEAD, it gets frozen at the fork point. */}
-					<MenuItem
-						icon={GitFork}
-						label={t("history.forkFromHere")}
-						hint={t("history.forkHint")}
-						onClick={() => void onFork(menu.node)}
-					/>
-					<MenuItem icon={Pencil} label={t("history.rename")} onClick={() => void onRename(menu.node)} />
-					<div className="my-1 h-px bg-border" />
-					<MenuItem
-						icon={Copy}
-						label={t("history.copyId")}
-						onClick={() => { void navigator.clipboard?.writeText(menu.node.session_id); setMenu(null); }}
-					/>
-				</div>
+				<ContextMenu
+					x={menu.x}
+					y={menu.y}
+					onDismiss={() => setMenu(null)}
+					items={buildHistoryMenuItems(menu.node, t, {
+						onJump: () => void onJump(menu.node),
+						onFork: () => void onFork(menu.node),
+						onRename: () => void onRename(menu.node),
+						onCopyId: () => {
+							void navigator.clipboard?.writeText(menu.node.session_id);
+						},
+					})}
+				/>
 			)}
 		</div>
 	);
 }
 
-function MenuItem({
-	icon: Icon,
-	label,
-	hint,
-	onClick,
-	disabled,
-}: {
-	icon: typeof GitFork;
-	label: string;
-	hint?: string;
-	onClick: () => void;
-	disabled?: boolean;
-}) {
-	return (
-		<button
-			disabled={disabled}
-			onClick={onClick}
-			title={hint}
-			className={cn(
-				"flex w-full items-start gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors",
-				disabled ? "cursor-not-allowed text-muted/40" : "text-fg hover:bg-accent/10 hover:text-accent",
-			)}
-		>
-			<Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-			<span className="flex flex-col gap-0.5">
-				<span>{label}</span>
-				{hint && <span className="text-[10px] font-normal text-muted">{hint}</span>}
-			</span>
-		</button>
-	);
+function buildHistoryMenuItems(
+	node: RpcHistoryTreeNode,
+	t: (k: string) => string,
+	handlers: { onJump: () => void; onFork: () => void; onRename: () => void; onCopyId: () => void },
+): ContextMenuItem[] {
+	return [
+		{
+			icon: CornerUpRight,
+			label: t("history.jumpHere"),
+			hint: node.is_active
+				? undefined
+				: node.closed
+					? t("history.jumpClosedHint")
+					: t("history.jumpOpenHint"),
+			disabled: node.is_active,
+			onClick: handlers.onJump,
+		},
+		{
+			icon: GitFork,
+			label: t("history.forkFromHere"),
+			hint: t("history.forkHint"),
+			onClick: handlers.onFork,
+		},
+		{
+			icon: Pencil,
+			label: t("history.rename"),
+			onClick: handlers.onRename,
+		},
+		{
+			icon: Copy,
+			label: t("history.copyId"),
+			onClick: handlers.onCopyId,
+		},
+	];
 }
 
 function TreeRow({

--- a/apps/web/src/views/FileExplorer.tsx
+++ b/apps/web/src/views/FileExplorer.tsx
@@ -10,16 +10,31 @@ import {
 	RefreshCw,
 	ArrowLeft,
 	Copy,
+	ClipboardCopy,
+	Eye,
 	ExternalLink,
+	ChevronsUpDown,
+	FolderSearch,
 } from "lucide-react";
-import { listDir, readFileContent, openInEditor, type DirEntry } from "@/lib/transport";
-import { EmptyState, ErrorBanner, Spinner } from "@/components/ui";
+import {
+	listDir,
+	readFileContent,
+	openInEditor,
+	revealPath,
+	type DirEntry,
+} from "@/lib/transport";
+import { EmptyState, ErrorBanner, Spinner, ContextMenu, type ContextMenuItem } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 function formatSize(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+interface ContextMenuState {
+	node: TreeNode;
+	x: number;
+	y: number;
 }
 
 function getLanguage(filePath: string): string {
@@ -55,9 +70,36 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 	const [fileLoading, setFileLoading] = useState(false);
 	const [fileError, setFileError] = useState("");
 	const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+	const [menu, setMenu] = useState<ContextMenuState | null>(null);
 	const fileContentRef = useRef<HTMLDivElement>(null);
 
 	const cwd = workspace ?? "";
+
+	// Dismiss context menu on any outside click / escape.
+	useEffect(() => {
+		if (!menu) return;
+		const onDown = () => setMenu(null);
+		const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setMenu(null); };
+		window.addEventListener("mousedown", onDown);
+		window.addEventListener("keydown", onKey);
+		return () => {
+			window.removeEventListener("mousedown", onDown);
+			window.removeEventListener("keydown", onKey);
+		};
+	}, [menu]);
+
+	const absolutePath = useCallback(
+		(relPath: string) => (cwd ? `${cwd.replace(/\/$/, "")}/${relPath}` : relPath),
+		[cwd],
+	);
+
+	const copyText = useCallback((text: string) => {
+		try {
+			void navigator.clipboard?.writeText(text);
+		} catch {
+			/* clipboard unavailable; ignore silently */
+		}
+	}, []);
 
 	const loadRoot = useCallback(async () => {
 		if (!cwd) return;
@@ -199,6 +241,10 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 								<li
 									key={node.path}
 									onClick={() => (node.is_dir ? void toggleExpand(node.path) : void openFile(node.path))}
+									onContextMenu={(e) => {
+										e.preventDefault();
+										setMenu({ node, x: e.clientX, y: e.clientY });
+									}}
 									className={cn(
 										"flex cursor-pointer items-center gap-1.5 px-3 py-1.5 transition-colors hover:bg-surface-2",
 										selectedFile === node.path && "bg-accent/10",
@@ -223,10 +269,42 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 						selectedFile={selectedFile}
 						onToggle={toggleExpand}
 						onOpenFile={openFile}
+						onContextMenu={(node, x, y) => setMenu({ node, x, y })}
 						depth={0}
 					/>
 				)}
 			</div>
+
+			{/* Context menu (rendered via portal-style fixed positioning) */}
+			{menu && (
+				<ContextMenu
+					x={menu.x}
+					y={menu.y}
+					onDismiss={() => setMenu(null)}
+					items={buildFileMenuItems(menu.node, t, {
+						absolutePath,
+						copyText,
+						onView: (node) => void openFile(node.path),
+						onOpenInEditor: (node) =>
+							openInEditor(cwd, node.path).catch((e) =>
+								console.error("openInEditor failed:", e),
+							),
+						onReveal: (node) =>
+							revealPath(cwd, node.path).catch((e) =>
+								console.error("revealPath failed:", e),
+							),
+						onCopyContent: async (node) => {
+							try {
+								const content = await readFileContent(cwd, node.path);
+								copyText(content);
+							} catch (e) {
+								console.error("readFileContent failed:", e);
+							}
+						},
+						onToggleExpand: (node) => void toggleExpand(node.path),
+					})}
+				/>
+			)}
 
 			{/* File content viewer */}
 			{selectedFile && (
@@ -281,12 +359,14 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 	);
 }
 
+
 function TreeList({
 	nodes,
 	expanded,
 	selectedFile,
 	onToggle,
 	onOpenFile,
+	onContextMenu,
 	depth,
 }: {
 	nodes: TreeNode[];
@@ -294,6 +374,7 @@ function TreeList({
 	selectedFile: string | null;
 	onToggle: (path: string) => void;
 	onOpenFile: (path: string) => void;
+	onContextMenu: (node: TreeNode, x: number, y: number) => void;
 	depth: number;
 }) {
 	return (
@@ -306,6 +387,7 @@ function TreeList({
 					selectedFile={selectedFile}
 					onToggle={onToggle}
 					onOpenFile={onOpenFile}
+					onContextMenu={onContextMenu}
 					depth={depth}
 				/>
 			))}
@@ -319,6 +401,7 @@ function TreeItem({
 	selectedFile,
 	onToggle,
 	onOpenFile,
+	onContextMenu,
 	depth,
 }: {
 	node: TreeNode;
@@ -326,6 +409,7 @@ function TreeItem({
 	selectedFile: string | null;
 	onToggle: (path: string) => void;
 	onOpenFile: (path: string) => void;
+	onContextMenu: (node: TreeNode, x: number, y: number) => void;
 	depth: number;
 }) {
 	const isOpen = expanded.has(node.path);
@@ -335,6 +419,10 @@ function TreeItem({
 		<li>
 			<div
 				onClick={() => (node.is_dir ? onToggle(node.path) : onOpenFile(node.path))}
+				onContextMenu={(e) => {
+					e.preventDefault();
+					onContextMenu(node, e.clientX, e.clientY);
+				}}
 				className={cn(
 					"flex cursor-pointer items-center gap-1.5 py-1 pr-3 transition-colors hover:bg-surface-2",
 					selectedFile === node.path && "bg-accent/10",
@@ -381,6 +469,7 @@ function TreeItem({
 							selectedFile={selectedFile}
 							onToggle={onToggle}
 							onOpenFile={onOpenFile}
+							onContextMenu={onContextMenu}
 							depth={depth + 1}
 						/>
 					) : (
@@ -392,6 +481,84 @@ function TreeItem({
 			)}
 		</li>
 	);
+}
+
+// --- Menu helpers ---
+
+interface FileMenuHandlers {
+	absolutePath: (rel: string) => string;
+	copyText: (text: string) => void;
+	onView: (node: TreeNode) => void;
+	onOpenInEditor: (node: TreeNode) => void;
+	onReveal: (node: TreeNode) => void;
+	onCopyContent: (node: TreeNode) => void;
+	onToggleExpand: (node: TreeNode) => void;
+}
+
+/**
+ * Build the context-menu items for a file or directory node. Items are split
+ * into two visual groups separated by the `---` divider marker (the shared
+ * ContextMenu component renders anything between dividers with a separator
+ * before it).
+ */
+function buildFileMenuItems(
+	node: TreeNode,
+	t: (k: string) => string,
+	h: FileMenuHandlers,
+): ContextMenuItem[] {
+	const abs = h.absolutePath(node.path);
+	const items: ContextMenuItem[] = [];
+
+	if (node.is_dir) {
+		items.push({
+			icon: ChevronsUpDown,
+			label: t("files.toggleExpand"),
+			onClick: () => h.onToggleExpand(node),
+		});
+	} else {
+		items.push({
+			icon: Eye,
+			label: t("files.view"),
+			onClick: () => h.onView(node),
+		});
+	}
+
+	items.push({
+		icon: ExternalLink,
+		label: t("files.openInEditor"),
+		onClick: () => h.onOpenInEditor(node),
+	});
+
+	items.push({ divider: true });
+
+	items.push({
+		icon: FolderSearch,
+		label: node.is_dir ? t("files.revealInFiles") : t("files.revealInFilesDir"),
+		onClick: () => h.onReveal(node),
+	});
+
+	items.push({ divider: true });
+
+	items.push({
+		icon: ClipboardCopy,
+		label: t("files.copyAbsolutePath"),
+		hint: abs,
+		onClick: () => h.copyText(abs),
+	});
+	items.push({
+		icon: Copy,
+		label: t("files.copyFileName"),
+		onClick: () => h.copyText(node.name),
+	});
+	if (!node.is_dir) {
+		items.push({
+			icon: Copy,
+			label: t("files.copyFileContent"),
+			onClick: () => h.onCopyContent(node),
+		});
+	}
+
+	return items;
 }
 
 // --- Tree helpers ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@tomsun28/pizza",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@tomsun28/pizza",
-			"version": "0.1.11",
+			"version": "0.1.12",
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tomsun28/pizza",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"description": "Pizza - Pizza is an event-driven agent. Every conversation, tool call, and file edit is an event in an immutable log. Your UI, the LLM context, and the session tree are all projections of that log.",
 	"type": "module",
 	"pizzaConfig": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@pizza/protocol",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"private": true,
 	"type": "module",
 	"main": "./index.ts",


### PR DESCRIPTION
## feat(desktop): add right-click context menu to file explorer

Right-clicking a file or directory in the right-dock file explorer now opens a context menu with common lightweight actions.

### Actions

**Files**
- View (open in the bottom preview pane)
- Open in editor (existing `open_in_editor`)
- Reveal containing folder (new `reveal_path` Tauri command — opens Finder with the file selected on macOS via `open -R`, opens the parent directory on Linux/Windows)
- Copy absolute path
- Copy file name
- Copy file content (re-reads via existing `read_file` and writes to clipboard)

**Directories**
- Expand / collapse (delegates to existing `toggleExpand`)
- Open in editor (passes the directory path to `open_in_editor`)
- Reveal in file manager (opens the directory itself)
- Copy absolute path
- Copy file name

### Implementation

- New Rust command `reveal_path(cwd, sub_path)` in `apps/desktop/src/bridge.rs`:
  - On macOS, files use `open -R <file>` (reveals + selects in Finder); directories use `open <dir>`.
  - Linux: `xdg-open`; Windows: `explorer`.
  - Registered in `apps/desktop/src/main.rs`.
- New `revealPath` wrapper in `apps/web/src/lib/transport.ts` (Tauri-only, no-op in browser preview).
- Extracted a shared, reusable `<ContextMenu>` component into `apps/web/src/components/ui.tsx`:
  - Discriminated union (`{ divider?: never; ... } | { divider: true }`) so dividers are type-safe.
  - Viewport-clamped positioning so it never overflows the narrow right dock.
  - Closes on outside `mousedown` and `Escape` (caller installs the window listeners in a `useEffect` while open).
- `BranchTreeExplorer` was migrated to use the new shared component (was previously carrying a private duplicate of the same markup — net code reduction even with the new feature).
- `FileExplorer` now wires `onContextMenu` on both tree rows and search-result rows, plus the close-on-outside-click effect.

### Safety

- Only zero-risk read/copy/open actions in this PR — no `rename`/`delete`/`new file`/`new folder` yet. Those need new Rust write commands + safe-mode approval flow and are intentionally deferred.
- All writes are guarded by `isTauri()`; browser preview mode silently no-ops.
- `clipboard` calls are wrapped in try/catch so an unavailable clipboard never throws.

### i18n

Added 7 keys under `files.*` in both `en.json` and `zh-CN.json`: `toggleExpand`, `view`, `revealInFiles`, `revealInFilesDir`, `copyAbsolutePath`, `copyFileName`, `copyFileContent`.

### Verification

- `tsc --noEmit --noUnusedLocals` — clean
- `cargo check` — clean
- `eslint` — clean
- `npm run build` — clean
- `PIZZA_OFFLINE=1 npm test` — 997 passed, 18 skipped (no regressions)
