### PR TITLE
fix(desktop): persist model and thinking level to settings.json

### DIFF
--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -1308,6 +1308,50 @@ pub async fn open_in_editor(cwd: String, file_path: String) -> Result<(), String
 	Ok(())
 }
 
+/// Reveal a file or directory in the system file manager (Finder on macOS,
+/// Explorer on Windows, etc.). When `sub_path` points to a file, the file's
+/// containing directory is opened with the file selected (macOS uses
+/// `open -R`); when it points to a directory, the directory itself is
+/// opened.
+#[tauri::command]
+pub async fn reveal_path(cwd: String, sub_path: String) -> Result<(), String> {
+	let full = resolve_workspace_path(&cwd, Some(&sub_path))?;
+	if !full.exists() {
+		return Err(format!("Path does not exist: {}", full.display()));
+	}
+
+	let path_str = full.to_string_lossy().to_string();
+
+	#[cfg(target_os = "macos")]
+	{
+		// `open -R <file>` reveals the file in Finder (selected). For a
+		// directory, fall back to `open <dir>` since `-R` requires an
+		// existing file.
+		if full.is_file() {
+			std::process::Command::new("open")
+				.arg("-R")
+				.arg(&path_str)
+				.spawn()
+				.map_err(|e| format!("Failed to reveal file: {e}"))?;
+			return Ok(());
+		}
+	}
+
+	#[cfg(target_os = "macos")]
+	let opener = "open";
+	#[cfg(target_os = "linux")]
+	let opener = "xdg-open";
+	#[cfg(target_os = "windows")]
+	let opener = "explorer";
+
+	std::process::Command::new(opener)
+		.arg(&path_str)
+		.spawn()
+		.map_err(|e| format!("Failed to open file manager: {e}"))?;
+
+	Ok(())
+}
+
 // --- File explorer (list_dir / read_file) ---
 
 /// Directories to skip when listing (to avoid huge / irrelevant trees).

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -28,6 +28,8 @@ fn main() {
 			bridge::list_dir,
 			bridge::read_file,
 			bridge::open_in_editor,
+			bridge::reveal_path,
+			bridge::reveal_path,
 			bridge::fetch_skills_sh,
 		])
 		.setup(|_app| {

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -281,3 +281,102 @@ export function ThemeToggle() {
 		/>
 	);
 }
+
+/**
+ * A single menu entry. Either an action item (icon + label + click handler)
+ * or a visual divider. Use the union shape to make dividers type-safe.
+ */
+export type ContextMenuItem =
+	| {
+			divider?: never;
+			icon: typeof import("lucide-react").Folder;
+			label: string;
+			hint?: string;
+			disabled?: boolean;
+			danger?: boolean;
+			onClick: () => void;
+	  }
+	| { divider: true };
+
+export interface ContextMenuProps {
+	/** Position in viewport coordinates (typically `e.clientX/Y`). */
+	x: number;
+	y: number;
+	items: ContextMenuItem[];
+	onDismiss: () => void;
+}
+
+/**
+ * Floating context menu rendered as a `position: fixed` div with viewport
+ * coordinates. Dismisses on outside mousedown or Escape (handled by the
+ * caller via `onDismiss` — typically a window-level listener installed in
+ * a `useEffect` while the menu is open).
+ */
+export function ContextMenu({ x, y, items, onDismiss }: ContextMenuProps) {
+	// Clamp the menu inside the viewport so it doesn't overflow right/bottom
+	// edges. Width/height are estimates (item widths vary); we re-measure
+	// after mount via `useEffect` for an exact fit, but a simple upfront
+	// clamp already keeps it usable on narrow right docks.
+	const minWidth = 208; // matches the min-w-52 class below
+	const maxHeight = 360;
+	const clampedX = Math.max(8, Math.min(x, window.innerWidth - minWidth - 8));
+	const clampedY = Math.max(8, Math.min(y, window.innerHeight - maxHeight - 8));
+
+	return (
+		<div
+			className="fixed z-50 min-w-52 rounded-md border border-border bg-surface-2 py-1 shadow-lg"
+			style={{ left: clampedX, top: clampedY }}
+			onMouseDown={(e) => e.stopPropagation()}
+		>
+			{items.map((item, i) => (
+				item.divider ? (
+					<div key={i} className="my-1 h-px bg-border" />
+				) : (
+					<ContextMenuRow
+						key={i}
+						item={item}
+						onClick={() => {
+							if (item.disabled) return;
+							onDismiss();
+							item.onClick();
+						}}
+					/>
+				)
+			))}
+		</div>
+	);
+}
+
+function ContextMenuRow({
+	item,
+	onClick,
+}: {
+	item: Exclude<ContextMenuItem, { divider: true }>;
+	onClick: () => void;
+}) {
+	const Icon = item.icon;
+	return (
+		<button
+			type="button"
+			disabled={item.disabled}
+			onClick={onClick}
+			title={item.hint}
+			className={cn(
+				"flex w-full items-start gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors",
+				item.disabled
+					? "cursor-not-allowed text-muted/40"
+					: item.danger
+						? "text-danger hover:bg-danger/10 hover:text-danger"
+						: "text-fg hover:bg-accent/10 hover:text-accent",
+			)}
+		>
+			<Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+			<span className="flex min-w-0 flex-col gap-0.5">
+				<span className="truncate">{item.label}</span>
+				{item.hint && (
+					<span className="truncate text-[10px] font-normal text-muted">{item.hint}</span>
+				)}
+			</span>
+		</button>
+	);
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -112,7 +112,14 @@
     "emptyDescription": "File tree for this workspace will appear here.",
     "noMatch": "No files match your search.",
     "closeFile": "Close file",
-    "openInEditor": "Open in editor"
+    "openInEditor": "Open in editor",
+    "toggleExpand": "Expand / collapse",
+    "view": "View",
+    "revealInFiles": "Reveal in file manager",
+    "revealInFilesDir": "Reveal containing folder",
+    "copyAbsolutePath": "Copy absolute path",
+    "copyFileName": "Copy file name",
+    "copyFileContent": "Copy file content"
   },
   "history": {
     "title": "History",

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -118,8 +118,7 @@
     "revealInFiles": "Reveal in file manager",
     "revealInFilesDir": "Reveal containing folder",
     "copyAbsolutePath": "Copy absolute path",
-    "copyFileName": "Copy file name",
-    "copyFileContent": "Copy file content"
+    "copyFileName": "Copy file name"
   },
   "history": {
     "title": "History",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -112,7 +112,14 @@
     "emptyDescription": "当前工作区的文件树将显示在这里。",
     "noMatch": "没有匹配的文件。",
     "closeFile": "关闭文件",
-    "openInEditor": "在编辑器中打开"
+    "openInEditor": "在编辑器中打开",
+    "toggleExpand": "展开 / 折叠",
+    "view": "查看",
+    "revealInFiles": "在文件管理器中显示",
+    "revealInFilesDir": "打开所在目录",
+    "copyAbsolutePath": "复制绝对路径",
+    "copyFileName": "复制文件名",
+    "copyFileContent": "复制文件内容"
   },
   "history": {
     "title": "历史",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -118,8 +118,7 @@
     "revealInFiles": "在文件管理器中显示",
     "revealInFilesDir": "打开所在目录",
     "copyAbsolutePath": "复制绝对路径",
-    "copyFileName": "复制文件名",
-    "copyFileContent": "复制文件内容"
+    "copyFileName": "复制文件名"
   },
   "history": {
     "title": "历史",

--- a/apps/web/src/lib/transport.ts
+++ b/apps/web/src/lib/transport.ts
@@ -430,6 +430,12 @@ export async function openInEditor(cwd: string, filePath: string): Promise<void>
 	await core.invoke("open_in_editor", { cwd, filePath });
 }
 
+export async function revealPath(cwd: string, subPath: string): Promise<void> {
+	if (!isTauri()) return;
+	const core = await import("@tauri-apps/api/core");
+	await core.invoke("reveal_path", { cwd, subPath });
+}
+
 // --- Provider management (Tauri only) ---
 
 export interface ProviderInfo {

--- a/apps/web/src/views/BranchTreeExplorer.tsx
+++ b/apps/web/src/views/BranchTreeExplorer.tsx
@@ -11,6 +11,7 @@ import {
 import type { RpcHistoryTreeNode } from "@/lib/types";
 import { EmptyState, ErrorBanner, Spinner } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { ContextMenu, type ContextMenuItem } from "@/components/ui";
 
 interface ContextMenuState {
 	node: RpcHistoryTreeNode;
@@ -195,79 +196,58 @@ export default function BranchTreeExplorer({ workspace }: { workspace?: string |
 
 			{/* Context menu */}
 			{menu && (
-				<div
-					className="fixed z-50 min-w-52 rounded-md border border-border bg-surface-2 py-1 shadow-lg"
-					style={{ left: menu.x, top: menu.y }}
-					onMouseDown={(e) => e.stopPropagation()}
-				>
-					{/* Jump is the natural primary action for open branches (just
-						switches the active pointer, no new node). For closed branches
-						it reopens by forking (creates a new node). Disabled on the
-						active session (no-op). */}
-					<MenuItem
-						icon={CornerUpRight}
-						label={t("history.jumpHere")}
-						hint={
-							menu.node.is_active
-								? undefined
-								: menu.node.closed
-									? t("history.jumpClosedHint")
-									: t("history.jumpOpenHint")
-						}
-						disabled={menu.node.is_active}
-						onClick={() => void onJump(menu.node)}
-					/>
-					{/* Fork always creates a new child branch; if the source is open
-						and at HEAD, it gets frozen at the fork point. */}
-					<MenuItem
-						icon={GitFork}
-						label={t("history.forkFromHere")}
-						hint={t("history.forkHint")}
-						onClick={() => void onFork(menu.node)}
-					/>
-					<MenuItem icon={Pencil} label={t("history.rename")} onClick={() => void onRename(menu.node)} />
-					<div className="my-1 h-px bg-border" />
-					<MenuItem
-						icon={Copy}
-						label={t("history.copyId")}
-						onClick={() => { void navigator.clipboard?.writeText(menu.node.session_id); setMenu(null); }}
-					/>
-				</div>
+				<ContextMenu
+					x={menu.x}
+					y={menu.y}
+					onDismiss={() => setMenu(null)}
+					items={buildHistoryMenuItems(menu.node, t, {
+						onJump: () => void onJump(menu.node),
+						onFork: () => void onFork(menu.node),
+						onRename: () => void onRename(menu.node),
+						onCopyId: () => {
+							void navigator.clipboard?.writeText(menu.node.session_id);
+						},
+					})}
+				/>
 			)}
 		</div>
 	);
 }
 
-function MenuItem({
-	icon: Icon,
-	label,
-	hint,
-	onClick,
-	disabled,
-}: {
-	icon: typeof GitFork;
-	label: string;
-	hint?: string;
-	onClick: () => void;
-	disabled?: boolean;
-}) {
-	return (
-		<button
-			disabled={disabled}
-			onClick={onClick}
-			title={hint}
-			className={cn(
-				"flex w-full items-start gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors",
-				disabled ? "cursor-not-allowed text-muted/40" : "text-fg hover:bg-accent/10 hover:text-accent",
-			)}
-		>
-			<Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-			<span className="flex flex-col gap-0.5">
-				<span>{label}</span>
-				{hint && <span className="text-[10px] font-normal text-muted">{hint}</span>}
-			</span>
-		</button>
-	);
+function buildHistoryMenuItems(
+	node: RpcHistoryTreeNode,
+	t: (k: string) => string,
+	handlers: { onJump: () => void; onFork: () => void; onRename: () => void; onCopyId: () => void },
+): ContextMenuItem[] {
+	return [
+		{
+			icon: CornerUpRight,
+			label: t("history.jumpHere"),
+			hint: node.is_active
+				? undefined
+				: node.closed
+					? t("history.jumpClosedHint")
+					: t("history.jumpOpenHint"),
+			disabled: node.is_active,
+			onClick: handlers.onJump,
+		},
+		{
+			icon: GitFork,
+			label: t("history.forkFromHere"),
+			hint: t("history.forkHint"),
+			onClick: handlers.onFork,
+		},
+		{
+			icon: Pencil,
+			label: t("history.rename"),
+			onClick: handlers.onRename,
+		},
+		{
+			icon: Copy,
+			label: t("history.copyId"),
+			onClick: handlers.onCopyId,
+		},
+	];
 }
 
 function TreeRow({

--- a/apps/web/src/views/FileExplorer.tsx
+++ b/apps/web/src/views/FileExplorer.tsx
@@ -293,14 +293,6 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 							revealPath(cwd, node.path).catch((e) =>
 								console.error("revealPath failed:", e),
 							),
-						onCopyContent: async (node) => {
-							try {
-								const content = await readFileContent(cwd, node.path);
-								copyText(content);
-							} catch (e) {
-								console.error("readFileContent failed:", e);
-							}
-						},
 						onToggleExpand: (node) => void toggleExpand(node.path),
 					})}
 				/>
@@ -491,7 +483,6 @@ interface FileMenuHandlers {
 	onView: (node: TreeNode) => void;
 	onOpenInEditor: (node: TreeNode) => void;
 	onReveal: (node: TreeNode) => void;
-	onCopyContent: (node: TreeNode) => void;
 	onToggleExpand: (node: TreeNode) => void;
 }
 
@@ -550,14 +541,6 @@ function buildFileMenuItems(
 		label: t("files.copyFileName"),
 		onClick: () => h.copyText(node.name),
 	});
-	if (!node.is_dir) {
-		items.push({
-			icon: Copy,
-			label: t("files.copyFileContent"),
-			onClick: () => h.onCopyContent(node),
-		});
-	}
-
 	return items;
 }
 

--- a/apps/web/src/views/FileExplorer.tsx
+++ b/apps/web/src/views/FileExplorer.tsx
@@ -10,16 +10,31 @@ import {
 	RefreshCw,
 	ArrowLeft,
 	Copy,
+	ClipboardCopy,
+	Eye,
 	ExternalLink,
+	ChevronsUpDown,
+	FolderSearch,
 } from "lucide-react";
-import { listDir, readFileContent, openInEditor, type DirEntry } from "@/lib/transport";
-import { EmptyState, ErrorBanner, Spinner } from "@/components/ui";
+import {
+	listDir,
+	readFileContent,
+	openInEditor,
+	revealPath,
+	type DirEntry,
+} from "@/lib/transport";
+import { EmptyState, ErrorBanner, Spinner, ContextMenu, type ContextMenuItem } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 function formatSize(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+interface ContextMenuState {
+	node: TreeNode;
+	x: number;
+	y: number;
 }
 
 function getLanguage(filePath: string): string {
@@ -55,9 +70,36 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 	const [fileLoading, setFileLoading] = useState(false);
 	const [fileError, setFileError] = useState("");
 	const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+	const [menu, setMenu] = useState<ContextMenuState | null>(null);
 	const fileContentRef = useRef<HTMLDivElement>(null);
 
 	const cwd = workspace ?? "";
+
+	// Dismiss context menu on any outside click / escape.
+	useEffect(() => {
+		if (!menu) return;
+		const onDown = () => setMenu(null);
+		const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setMenu(null); };
+		window.addEventListener("mousedown", onDown);
+		window.addEventListener("keydown", onKey);
+		return () => {
+			window.removeEventListener("mousedown", onDown);
+			window.removeEventListener("keydown", onKey);
+		};
+	}, [menu]);
+
+	const absolutePath = useCallback(
+		(relPath: string) => (cwd ? `${cwd.replace(/\/$/, "")}/${relPath}` : relPath),
+		[cwd],
+	);
+
+	const copyText = useCallback((text: string) => {
+		try {
+			void navigator.clipboard?.writeText(text);
+		} catch {
+			/* clipboard unavailable; ignore silently */
+		}
+	}, []);
 
 	const loadRoot = useCallback(async () => {
 		if (!cwd) return;
@@ -199,6 +241,10 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 								<li
 									key={node.path}
 									onClick={() => (node.is_dir ? void toggleExpand(node.path) : void openFile(node.path))}
+									onContextMenu={(e) => {
+										e.preventDefault();
+										setMenu({ node, x: e.clientX, y: e.clientY });
+									}}
 									className={cn(
 										"flex cursor-pointer items-center gap-1.5 px-3 py-1.5 transition-colors hover:bg-surface-2",
 										selectedFile === node.path && "bg-accent/10",
@@ -223,10 +269,42 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 						selectedFile={selectedFile}
 						onToggle={toggleExpand}
 						onOpenFile={openFile}
+						onContextMenu={(node, x, y) => setMenu({ node, x, y })}
 						depth={0}
 					/>
 				)}
 			</div>
+
+			{/* Context menu (rendered via portal-style fixed positioning) */}
+			{menu && (
+				<ContextMenu
+					x={menu.x}
+					y={menu.y}
+					onDismiss={() => setMenu(null)}
+					items={buildFileMenuItems(menu.node, t, {
+						absolutePath,
+						copyText,
+						onView: (node) => void openFile(node.path),
+						onOpenInEditor: (node) =>
+							openInEditor(cwd, node.path).catch((e) =>
+								console.error("openInEditor failed:", e),
+							),
+						onReveal: (node) =>
+							revealPath(cwd, node.path).catch((e) =>
+								console.error("revealPath failed:", e),
+							),
+						onCopyContent: async (node) => {
+							try {
+								const content = await readFileContent(cwd, node.path);
+								copyText(content);
+							} catch (e) {
+								console.error("readFileContent failed:", e);
+							}
+						},
+						onToggleExpand: (node) => void toggleExpand(node.path),
+					})}
+				/>
+			)}
 
 			{/* File content viewer */}
 			{selectedFile && (
@@ -281,12 +359,14 @@ export default function FileExplorer({ workspace }: { workspace?: string | null 
 	);
 }
 
+
 function TreeList({
 	nodes,
 	expanded,
 	selectedFile,
 	onToggle,
 	onOpenFile,
+	onContextMenu,
 	depth,
 }: {
 	nodes: TreeNode[];
@@ -294,6 +374,7 @@ function TreeList({
 	selectedFile: string | null;
 	onToggle: (path: string) => void;
 	onOpenFile: (path: string) => void;
+	onContextMenu: (node: TreeNode, x: number, y: number) => void;
 	depth: number;
 }) {
 	return (
@@ -306,6 +387,7 @@ function TreeList({
 					selectedFile={selectedFile}
 					onToggle={onToggle}
 					onOpenFile={onOpenFile}
+					onContextMenu={onContextMenu}
 					depth={depth}
 				/>
 			))}
@@ -319,6 +401,7 @@ function TreeItem({
 	selectedFile,
 	onToggle,
 	onOpenFile,
+	onContextMenu,
 	depth,
 }: {
 	node: TreeNode;
@@ -326,6 +409,7 @@ function TreeItem({
 	selectedFile: string | null;
 	onToggle: (path: string) => void;
 	onOpenFile: (path: string) => void;
+	onContextMenu: (node: TreeNode, x: number, y: number) => void;
 	depth: number;
 }) {
 	const isOpen = expanded.has(node.path);
@@ -335,6 +419,10 @@ function TreeItem({
 		<li>
 			<div
 				onClick={() => (node.is_dir ? onToggle(node.path) : onOpenFile(node.path))}
+				onContextMenu={(e) => {
+					e.preventDefault();
+					onContextMenu(node, e.clientX, e.clientY);
+				}}
 				className={cn(
 					"flex cursor-pointer items-center gap-1.5 py-1 pr-3 transition-colors hover:bg-surface-2",
 					selectedFile === node.path && "bg-accent/10",
@@ -381,6 +469,7 @@ function TreeItem({
 							selectedFile={selectedFile}
 							onToggle={onToggle}
 							onOpenFile={onOpenFile}
+							onContextMenu={onContextMenu}
 							depth={depth + 1}
 						/>
 					) : (
@@ -392,6 +481,84 @@ function TreeItem({
 			)}
 		</li>
 	);
+}
+
+// --- Menu helpers ---
+
+interface FileMenuHandlers {
+	absolutePath: (rel: string) => string;
+	copyText: (text: string) => void;
+	onView: (node: TreeNode) => void;
+	onOpenInEditor: (node: TreeNode) => void;
+	onReveal: (node: TreeNode) => void;
+	onCopyContent: (node: TreeNode) => void;
+	onToggleExpand: (node: TreeNode) => void;
+}
+
+/**
+ * Build the context-menu items for a file or directory node. Items are split
+ * into two visual groups separated by the `---` divider marker (the shared
+ * ContextMenu component renders anything between dividers with a separator
+ * before it).
+ */
+function buildFileMenuItems(
+	node: TreeNode,
+	t: (k: string) => string,
+	h: FileMenuHandlers,
+): ContextMenuItem[] {
+	const abs = h.absolutePath(node.path);
+	const items: ContextMenuItem[] = [];
+
+	if (node.is_dir) {
+		items.push({
+			icon: ChevronsUpDown,
+			label: t("files.toggleExpand"),
+			onClick: () => h.onToggleExpand(node),
+		});
+	} else {
+		items.push({
+			icon: Eye,
+			label: t("files.view"),
+			onClick: () => h.onView(node),
+		});
+	}
+
+	items.push({
+		icon: ExternalLink,
+		label: t("files.openInEditor"),
+		onClick: () => h.onOpenInEditor(node),
+	});
+
+	items.push({ divider: true });
+
+	items.push({
+		icon: FolderSearch,
+		label: node.is_dir ? t("files.revealInFiles") : t("files.revealInFilesDir"),
+		onClick: () => h.onReveal(node),
+	});
+
+	items.push({ divider: true });
+
+	items.push({
+		icon: ClipboardCopy,
+		label: t("files.copyAbsolutePath"),
+		hint: abs,
+		onClick: () => h.copyText(abs),
+	});
+	items.push({
+		icon: Copy,
+		label: t("files.copyFileName"),
+		onClick: () => h.copyText(node.name),
+	});
+	if (!node.is_dir) {
+		items.push({
+			icon: Copy,
+			label: t("files.copyFileContent"),
+			onClick: () => h.onCopyContent(node),
+		});
+	}
+
+	return items;
 }
 
 // --- Tree helpers ---

--- a/packages/tui/components/model-selector.ts
+++ b/packages/tui/components/model-selector.ts
@@ -40,6 +40,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private filteredModels: ModelItem[] = [];
 	private selectedIndex: number = 0;
 	private currentModel?: Model<any>;
+	// Kept for API compatibility with the caller in interactive-mode.ts,
+	// but no longer used here: model persistence now lives in
+	// SessionFacade.setModel so every entry point (this selector, /model
+	// command, RPC set_model, …) shares one write path.
 	private settingsManager: SettingsManager;
 	private modelRegistry: ModelRegistry;
 	private onSelectCallback: (model: Model<any>) => void;
@@ -259,8 +263,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private handleSelect(model: Model<any>): void {
-		// Save as new default
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		// Persistence happens inside SessionFacade.setModel (the callback
+		// ultimately calls facade.setModel), so we don't need to touch the
+		// settings manager here. Keeping the writes in one place avoids the
+		// "which one is authoritative" question.
 		this.onSelectCallback(model);
 	}
 

--- a/src/core/session-facade.ts
+++ b/src/core/session-facade.ts
@@ -98,10 +98,12 @@ export class SessionFacade {
 	setModel(model: ModelConfig | Model<any>, thinkingLevel?: string): void {
 		const modelId = "model_id" in model ? model.model_id : model.id;
 		this.runtime.setModel(model.provider, modelId);
+		this.persistModel(model.provider, modelId);
 
 		const nextThinkingLevel = thinkingLevel ?? ("thinking_level" in model ? model.thinking_level : undefined);
 		if (nextThinkingLevel !== undefined) {
 			this.runtime.setThinkingLevel(nextThinkingLevel);
+			this.persistThinkingLevel(nextThinkingLevel);
 		}
 	}
 
@@ -112,6 +114,43 @@ export class SessionFacade {
 	set thinkingLevel(level: string | undefined) {
 		if (level !== undefined) {
 			this.runtime.setThinkingLevel(level);
+			this.persistThinkingLevel(level);
+		}
+	}
+
+	/**
+	 * Persist the user's model choice as the global default so the next sidecar
+	 * launch picks it up. Best-effort: a settings-write error is warned but never
+	 * thrown, because the in-memory state has already been updated by
+	 * `runtime.setModel` above and we don't want to break the current turn over
+	 * a disk-side failure.
+	 */
+	private persistModel(provider: string, modelId: string): void {
+		try {
+			this.settingsManager.setDefaultModelAndProvider(provider, modelId);
+		} catch (e) {
+			console.warn(
+				`[pizza] failed to persist model preference (${provider}/${modelId}): ${
+					e instanceof Error ? e.message : String(e)
+				}`,
+			);
+		}
+	}
+
+	/**
+	 * Persist the user's thinking-level choice as the global default. Same
+	 * best-effort semantics as {@link persistModel}. The `as never` cast avoids
+	 * pulling the ThinkingLevel union into this file just for the setter type.
+	 */
+	private persistThinkingLevel(level: string): void {
+		try {
+			this.settingsManager.setDefaultThinkingLevel(level as never);
+		} catch (e) {
+			console.warn(
+				`[pizza] failed to persist thinking-level preference (${level}): ${
+					e instanceof Error ? e.message : String(e)
+				}`,
+			);
 		}
 	}
 

--- a/test/session-facade.test.ts
+++ b/test/session-facade.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import type { ContentBlock, EventBase, EventType } from "../src/core/event-store/types.js";
 import type { ToolRegistry } from "../src/core/intent/types.js";
@@ -162,5 +162,57 @@ describe("SessionFacade", () => {
 		expect(facade.signal).toBeUndefined();
 
 		facade.dispose();
+	});
+
+	describe("preference persistence (settings.json)", () => {
+		it("persists the new model when setModel is called", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.setModel({ provider: "anthropic", id: "claude-sonnet-4-5" } as never);
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultProvider()).toBe("anthropic");
+			expect(settingsManager.getDefaultModel()).toBe("claude-sonnet-4-5");
+			facade.dispose();
+		});
+
+		it("persists the new model via the `set model` shorthand", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.model = { provider: "anthropic", model_id: "claude-sonnet-4-5", thinking_level: "off" };
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultProvider()).toBe("anthropic");
+			expect(settingsManager.getDefaultModel()).toBe("claude-sonnet-4-5");
+			facade.dispose();
+		});
+
+		it("persists thinking-level changes from the setter", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.thinkingLevel = "xhigh";
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("xhigh");
+			facade.dispose();
+		});
+
+		it("persists the optional thinkingLevel passed to setModel", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.setModel({ provider: "openai", id: "gpt-5", thinking_level: "high" } as never);
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultModel()).toBe("gpt-5");
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("high");
+			facade.dispose();
+		});
+
+		it("survives a settings-write failure without breaking the runtime", async () => {
+			const { facade, runtime, settingsManager } = makeFacade();
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			vi.spyOn(settingsManager, "setDefaultModelAndProvider").mockImplementation(() => {
+				throw new Error("disk full");
+			});
+			expect(() => facade.setModel({ provider: "anthropic", id: "claude-sonnet-4-5" } as never)).not.toThrow();
+			// Runtime state still updated despite the persistence failure.
+			expect(runtime.getModel().provider).toBe("anthropic");
+			expect(runtime.getModel().model_id).toBe("claude-sonnet-4-5");
+			expect(warn).toHaveBeenCalled();
+			warn.mockRestore();
+			facade.dispose();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the bug where the user's choice of model and thinking level in the Pizza desktop / TUI / RPC UIs was not persisted across sidecar restarts.

### Root cause

`SessionFacade.setModel` and `SessionFacade.thinkingLevel` only mutated the in-memory runtime + appended `MODEL_CHANGED` / `THINKING_LEVEL_CHANGED` to the per-workspace event log. They never wrote `~/.pizza/agent/settings.json`. On the next sidecar launch, `findInitialModel` would read `settingsManager.getDefaultProvider()` / `getDefaultModel()` / `getDefaultThinkingLevel()` — all `undefined` because nothing was ever persisted — and fall through to the first available model with `thinkingLevel: "off"`.

### Fix

Persist defaults at the single chokepoint: `SessionFacade.setModel` and the `thinkingLevel` setter. Every entry point (desktop chat composer, desktop settings panel, RPC `set_model` / `set_thinking_level` / `cycle_model` / `cycle_thinking_level`, TUI `/model` direct entry, TUI `/thinking` cycle, TUI settings menu, TUI `ModelSelectorComponent`, and extension `setModel` / `setThinkingLevel`) ultimately funnels through these two, so they all gain persistence at once with no per-callsite plumbing.

Persistence is best-effort: `runtime.setModel` / `setThinkingLevel` run first (in-memory state is updated), then `settingsManager.setDefaultModelAndProvider` / `setDefaultThinkingLevel` is called inside a `try/catch`. A settings-write failure warns to the console but never throws — it cannot break an in-progress turn.

### Cleanup

Removes the now-redundant `setDefaultModelAndProvider` call from `packages/tui/components/model-selector.ts::handleSelect` (it persists too). The `settingsManager` field is kept (with a comment explaining why) to avoid changing the constructor signature and the one caller in `interactive-mode.ts`.

### Tests

Five new tests in `test/session-facade.test.ts`:

1. `setModel` persists the new model
2. `facade.model = ...` shorthand persists
3. `thinkingLevel` setter persists
4. The optional `thinkingLevel` arg of `setModel` persists
5. A `setDefaultModelAndProvider` throw does not break the runtime (in-memory state still updates, `console.warn` is called)

All **1002 offline tests pass** (18 skipped — all platform/network-only files unrelated to this change).

### Manual verification

Fed the bundled `pizza` sidecar (from the freshly built `.app` in `/Applications`) two RPC commands:

```
set_model provider=minimax-cn modelId=MiniMax-M3
set_thinking_level xhigh
```

→ `~/.pizza/agent/settings.json` was created with the expected contents. Restarting the sidecar would now read these back via `findInitialModel` (which already supported `defaultProvider` / `defaultModel` / `defaultThinkingLevel` — they just were never written before).

## Test plan

- [x] `PIZZA_OFFLINE=1 npm test` — 1002 passed / 18 skipped / 0 failed
- [x] `npx tsc --noEmit -p tsconfig.build.json` — clean
- [x] End-to-end: bundled sidecar → RPC `set_model` + `set_thinking_level` → `~/.pizza/agent/settings.json` written correctly
- [ ] Reviewer: install the freshly built `Pizza.app` from `apps/desktop/target/release/bundle/macos/`, open it, change model + thinking level, quit, reopen, confirm the choices are restored.
