### PR TITLE
fix(desktop): persist model and thinking level to settings.json

### DIFF
--- a/packages/tui/components/model-selector.ts
+++ b/packages/tui/components/model-selector.ts
@@ -40,6 +40,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private filteredModels: ModelItem[] = [];
 	private selectedIndex: number = 0;
 	private currentModel?: Model<any>;
+	// Kept for API compatibility with the caller in interactive-mode.ts,
+	// but no longer used here: model persistence now lives in
+	// SessionFacade.setModel so every entry point (this selector, /model
+	// command, RPC set_model, …) shares one write path.
 	private settingsManager: SettingsManager;
 	private modelRegistry: ModelRegistry;
 	private onSelectCallback: (model: Model<any>) => void;
@@ -259,8 +263,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	}
 
 	private handleSelect(model: Model<any>): void {
-		// Save as new default
-		this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
+		// Persistence happens inside SessionFacade.setModel (the callback
+		// ultimately calls facade.setModel), so we don't need to touch the
+		// settings manager here. Keeping the writes in one place avoids the
+		// "which one is authoritative" question.
 		this.onSelectCallback(model);
 	}
 

--- a/src/core/session-facade.ts
+++ b/src/core/session-facade.ts
@@ -98,10 +98,12 @@ export class SessionFacade {
 	setModel(model: ModelConfig | Model<any>, thinkingLevel?: string): void {
 		const modelId = "model_id" in model ? model.model_id : model.id;
 		this.runtime.setModel(model.provider, modelId);
+		this.persistModel(model.provider, modelId);
 
 		const nextThinkingLevel = thinkingLevel ?? ("thinking_level" in model ? model.thinking_level : undefined);
 		if (nextThinkingLevel !== undefined) {
 			this.runtime.setThinkingLevel(nextThinkingLevel);
+			this.persistThinkingLevel(nextThinkingLevel);
 		}
 	}
 
@@ -112,6 +114,43 @@ export class SessionFacade {
 	set thinkingLevel(level: string | undefined) {
 		if (level !== undefined) {
 			this.runtime.setThinkingLevel(level);
+			this.persistThinkingLevel(level);
+		}
+	}
+
+	/**
+	 * Persist the user's model choice as the global default so the next sidecar
+	 * launch picks it up. Best-effort: a settings-write error is warned but never
+	 * thrown, because the in-memory state has already been updated by
+	 * `runtime.setModel` above and we don't want to break the current turn over
+	 * a disk-side failure.
+	 */
+	private persistModel(provider: string, modelId: string): void {
+		try {
+			this.settingsManager.setDefaultModelAndProvider(provider, modelId);
+		} catch (e) {
+			console.warn(
+				`[pizza] failed to persist model preference (${provider}/${modelId}): ${
+					e instanceof Error ? e.message : String(e)
+				}`,
+			);
+		}
+	}
+
+	/**
+	 * Persist the user's thinking-level choice as the global default. Same
+	 * best-effort semantics as {@link persistModel}. The `as never` cast avoids
+	 * pulling the ThinkingLevel union into this file just for the setter type.
+	 */
+	private persistThinkingLevel(level: string): void {
+		try {
+			this.settingsManager.setDefaultThinkingLevel(level as never);
+		} catch (e) {
+			console.warn(
+				`[pizza] failed to persist thinking-level preference (${level}): ${
+					e instanceof Error ? e.message : String(e)
+				}`,
+			);
 		}
 	}
 

--- a/test/session-facade.test.ts
+++ b/test/session-facade.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../src/core/auth-storage.js";
 import type { ContentBlock, EventBase, EventType } from "../src/core/event-store/types.js";
 import type { ToolRegistry } from "../src/core/intent/types.js";
@@ -162,5 +162,57 @@ describe("SessionFacade", () => {
 		expect(facade.signal).toBeUndefined();
 
 		facade.dispose();
+	});
+
+	describe("preference persistence (settings.json)", () => {
+		it("persists the new model when setModel is called", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.setModel({ provider: "anthropic", id: "claude-sonnet-4-5" } as never);
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultProvider()).toBe("anthropic");
+			expect(settingsManager.getDefaultModel()).toBe("claude-sonnet-4-5");
+			facade.dispose();
+		});
+
+		it("persists the new model via the `set model` shorthand", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.model = { provider: "anthropic", model_id: "claude-sonnet-4-5", thinking_level: "off" };
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultProvider()).toBe("anthropic");
+			expect(settingsManager.getDefaultModel()).toBe("claude-sonnet-4-5");
+			facade.dispose();
+		});
+
+		it("persists thinking-level changes from the setter", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.thinkingLevel = "xhigh";
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("xhigh");
+			facade.dispose();
+		});
+
+		it("persists the optional thinkingLevel passed to setModel", async () => {
+			const { facade, settingsManager } = makeFacade();
+			facade.setModel({ provider: "openai", id: "gpt-5", thinking_level: "high" } as never);
+			await settingsManager.flush();
+			expect(settingsManager.getDefaultModel()).toBe("gpt-5");
+			expect(settingsManager.getDefaultThinkingLevel()).toBe("high");
+			facade.dispose();
+		});
+
+		it("survives a settings-write failure without breaking the runtime", async () => {
+			const { facade, runtime, settingsManager } = makeFacade();
+			const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+			vi.spyOn(settingsManager, "setDefaultModelAndProvider").mockImplementation(() => {
+				throw new Error("disk full");
+			});
+			expect(() => facade.setModel({ provider: "anthropic", id: "claude-sonnet-4-5" } as never)).not.toThrow();
+			// Runtime state still updated despite the persistence failure.
+			expect(runtime.getModel().provider).toBe("anthropic");
+			expect(runtime.getModel().model_id).toBe("claude-sonnet-4-5");
+			expect(warn).toHaveBeenCalled();
+			warn.mockRestore();
+			facade.dispose();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the bug where the user's choice of model and thinking level in the Pizza desktop / TUI / RPC UIs was not persisted across sidecar restarts.

### Root cause

`SessionFacade.setModel` and `SessionFacade.thinkingLevel` only mutated the in-memory runtime + appended `MODEL_CHANGED` / `THINKING_LEVEL_CHANGED` to the per-workspace event log. They never wrote `~/.pizza/agent/settings.json`. On the next sidecar launch, `findInitialModel` would read `settingsManager.getDefaultProvider()` / `getDefaultModel()` / `getDefaultThinkingLevel()` — all `undefined` because nothing was ever persisted — and fall through to the first available model with `thinkingLevel: "off"`.

### Fix

Persist defaults at the single chokepoint: `SessionFacade.setModel` and the `thinkingLevel` setter. Every entry point (desktop chat composer, desktop settings panel, RPC `set_model` / `set_thinking_level` / `cycle_model` / `cycle_thinking_level`, TUI `/model` direct entry, TUI `/thinking` cycle, TUI settings menu, TUI `ModelSelectorComponent`, and extension `setModel` / `setThinkingLevel`) ultimately funnels through these two, so they all gain persistence at once with no per-callsite plumbing.

Persistence is best-effort: `runtime.setModel` / `setThinkingLevel` run first (in-memory state is updated), then `settingsManager.setDefaultModelAndProvider` / `setDefaultThinkingLevel` is called inside a `try/catch`. A settings-write failure warns to the console but never throws — it cannot break an in-progress turn.

### Cleanup

Removes the now-redundant `setDefaultModelAndProvider` call from `packages/tui/components/model-selector.ts::handleSelect` (it persists too). The `settingsManager` field is kept (with a comment explaining why) to avoid changing the constructor signature and the one caller in `interactive-mode.ts`.

### Tests

Five new tests in `test/session-facade.test.ts`:

1. `setModel` persists the new model
2. `facade.model = ...` shorthand persists
3. `thinkingLevel` setter persists
4. The optional `thinkingLevel` arg of `setModel` persists
5. A `setDefaultModelAndProvider` throw does not break the runtime (in-memory state still updates, `console.warn` is called)

All **1002 offline tests pass** (18 skipped — all platform/network-only files unrelated to this change).

### Manual verification

Fed the bundled `pizza` sidecar (from the freshly built `.app` in `/Applications`) two RPC commands:

```
set_model provider=minimax-cn modelId=MiniMax-M3
set_thinking_level xhigh
```

→ `~/.pizza/agent/settings.json` was created with the expected contents. Restarting the sidecar would now read these back via `findInitialModel` (which already supported `defaultProvider` / `defaultModel` / `defaultThinkingLevel` — they just were never written before).

## Test plan

- [x] `PIZZA_OFFLINE=1 npm test` — 1002 passed / 18 skipped / 0 failed
- [x] `npx tsc --noEmit -p tsconfig.build.json` — clean
- [x] End-to-end: bundled sidecar → RPC `set_model` + `set_thinking_level` → `~/.pizza/agent/settings.json` written correctly
- [ ] Reviewer: install the freshly built `Pizza.app` from `apps/desktop/target/release/bundle/macos/`, open it, change model + thinking level, quit, reopen, confirm the choices are restored.
