### PR TITLE
fix(desktop): restore file drag attachments

### DIFF
--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -1,3 +1,5 @@
+use base64::Engine;
+use serde::Serialize;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read, Write};
@@ -25,7 +27,7 @@ fn read_api_key(provider: &str) -> Option<String> {
 	}
 }
 
-fn log_file(msg: &str) {
+pub(crate) fn log_file(msg: &str) {
 	use std::io::Write;
 	if let Ok(mut f) = std::fs::OpenOptions::new()
 		.create(true)
@@ -219,6 +221,17 @@ fn resolve_pizza_command(app: &AppHandle) -> (String, Vec<String>) {
 struct SidecarEntry {
 	child: Child,
 	stdin: ChildStdin,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileAttachmentInfo {
+	kind: &'static str,
+	absolute_path: String,
+	relative_path: String,
+	mime_type: String,
+	name: String,
+	size: u64,
 }
 
 pub struct BridgeState {
@@ -1313,6 +1326,136 @@ pub async fn reveal_file(absolute_path: String) -> Result<(), String> {
 		.map_err(|e| format!("Failed to open file manager: {e}"))?;
 
 	Ok(())
+}
+
+fn file_name_for_path(path: &std::path::Path) -> String {
+	path.file_name()
+		.and_then(|name| name.to_str())
+		.filter(|name| !name.is_empty())
+		.unwrap_or("untitled")
+		.to_string()
+}
+
+fn sanitize_upload_filename(filename: &str) -> String {
+	let cleaned: String = filename
+		.chars()
+		.map(|c| {
+			if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ' ') {
+				c
+			} else {
+				'_'
+			}
+		})
+		.collect();
+	let trimmed = cleaned.trim().trim_matches('.').to_string();
+	if trimmed.is_empty() {
+		"untitled".to_string()
+	} else {
+		trimmed
+	}
+}
+
+fn guess_mime_type(path: &std::path::Path, fallback: &str) -> String {
+	if !fallback.is_empty() && fallback != "application/octet-stream" {
+		return fallback.to_string();
+	}
+	let ext = path
+		.extension()
+		.and_then(|ext| ext.to_str())
+		.unwrap_or("")
+		.to_ascii_lowercase();
+	match ext.as_str() {
+		"jpg" | "jpeg" => "image/jpeg",
+		"png" => "image/png",
+		"gif" => "image/gif",
+		"webp" => "image/webp",
+		"svg" => "image/svg+xml",
+		"pdf" => "application/pdf",
+		"txt" | "log" => "text/plain",
+		"md" | "markdown" => "text/markdown",
+		"json" => "application/json",
+		"csv" => "text/csv",
+		"html" | "htm" => "text/html",
+		"css" => "text/css",
+		"js" | "mjs" | "cjs" => "text/javascript",
+		"ts" | "tsx" => "text/typescript",
+		"py" => "text/x-python",
+		"rs" => "text/rust",
+		"doc" => "application/msword",
+		"docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"xls" => "application/vnd.ms-excel",
+		"xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		"ppt" => "application/vnd.ms-powerpoint",
+		"pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+		"zip" => "application/zip",
+		_ => fallback,
+	}
+	.to_string()
+}
+
+#[tauri::command]
+pub async fn describe_dropped_files(paths: Vec<String>) -> Result<Vec<FileAttachmentInfo>, String> {
+	let mut files = Vec::new();
+	for raw_path in paths {
+		let path = PathBuf::from(&raw_path);
+		let absolute = path.canonicalize().unwrap_or(path);
+		let metadata = std::fs::metadata(&absolute)
+			.map_err(|e| format!("Failed to read dropped path {}: {e}", absolute.display()))?;
+		let fallback = if metadata.is_dir() {
+			"application/x-directory"
+		} else {
+			"application/octet-stream"
+		};
+		files.push(FileAttachmentInfo {
+			kind: "file",
+			absolute_path: absolute.to_string_lossy().to_string(),
+			relative_path: absolute.to_string_lossy().to_string(),
+			mime_type: guess_mime_type(&absolute, fallback),
+			name: file_name_for_path(&absolute),
+			size: metadata.len(),
+		});
+	}
+	Ok(files)
+}
+
+#[tauri::command]
+pub async fn save_upload(
+	window: tauri::Window,
+	state: tauri::State<'_, BridgeState>,
+	filename: String,
+	mime_type: String,
+	data_b64: String,
+) -> Result<FileAttachmentInfo, String> {
+	let window_label = window.label().to_string();
+	let cwd = {
+		let active = state.active.lock().unwrap();
+		active
+			.get(&window_label)
+			.cloned()
+			.ok_or("No active workspace for this window")?
+	};
+	let safe_name = sanitize_upload_filename(&filename);
+	let upload_dir = PathBuf::from(&cwd).join(".pizza").join("uploads");
+	std::fs::create_dir_all(&upload_dir)
+		.map_err(|e| format!("Failed to create upload directory: {e}"))?;
+	let stored_name = format!("{}-{}", uuid::Uuid::new_v4(), safe_name);
+	let path = upload_dir.join(stored_name);
+	let bytes = base64::engine::general_purpose::STANDARD
+		.decode(data_b64)
+		.map_err(|e| format!("Invalid upload data: {e}"))?;
+	std::fs::write(&path, &bytes).map_err(|e| format!("Failed to save upload: {e}"))?;
+	let relative_path = path
+		.strip_prefix(&cwd)
+		.map(|p| p.to_string_lossy().to_string())
+		.unwrap_or_else(|_| path.to_string_lossy().to_string());
+	Ok(FileAttachmentInfo {
+		kind: "file",
+		absolute_path: path.to_string_lossy().to_string(),
+		relative_path,
+		mime_type: guess_mime_type(&path, &mime_type),
+		name: filename,
+		size: bytes.len() as u64,
+	})
 }
 
 /// Wrap an absolute path so it can be passed to the shell quote-free.

--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -1292,7 +1292,6 @@ pub async fn delete_workspace(
 	Ok(())
 }
 
-
 /// Reveal an arbitrary file in the system file manager (Finder on macOS,
 /// Explorer on Windows, the desktop file manager on Linux). The path should
 /// be absolute — the sidecar places uploads under <cwd>/.pizza/uploads/...
@@ -1460,7 +1459,9 @@ pub async fn save_upload(
 
 /// Wrap an absolute path so it can be passed to the shell quote-free.
 fn quote_arg(s: &str) -> String {
-	if s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-' | '~')) {
+	if s.chars()
+		.all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-' | '~'))
+	{
 		s.to_string()
 	} else {
 		format!("'{}'", s.replace('\'', "'\\''"))

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -3,7 +3,7 @@
 
 mod bridge;
 
-use tauri::{Manager, WindowEvent};
+use tauri::{DragDropEvent, Emitter, Manager, WindowEvent};
 
 fn main() {
 	env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -14,14 +14,16 @@ fn main() {
 		.invoke_handler(tauri::generate_handler![
 			bridge::init_sidecar,
 			bridge::stop_sidecar,
-			bridge::rpc_command,
-			bridge::new_workspace,
-			bridge::list_workspaces,
-			bridge::delete_workspace,
-			bridge::reveal_workspace,
-			bridge::reveal_file,
-			bridge::list_providers,
-			bridge::set_provider_api_key,
+				bridge::rpc_command,
+				bridge::new_workspace,
+				bridge::list_workspaces,
+				bridge::delete_workspace,
+				bridge::reveal_workspace,
+				bridge::reveal_file,
+				bridge::describe_dropped_files,
+				bridge::save_upload,
+				bridge::list_providers,
+				bridge::set_provider_api_key,
 			bridge::remove_provider_api_key,
 			bridge::restart_sidecar,
 			bridge::set_window_background,
@@ -42,14 +44,25 @@ fn main() {
 			}
 			Ok(())
 		})
-		.on_window_event(|window, event| {
-			if let WindowEvent::CloseRequested { .. } = event {
-				let label = window.label().to_string();
-				log::info!("window {} closed, stopping its sidecar", label);
-				let state = window.app_handle().state::<bridge::BridgeState>();
-				bridge::kill_sidecar_for_window(state.inner(), &label);
-			}
-		})
+			.on_window_event(|window, event| {
+				match event {
+					WindowEvent::CloseRequested { .. } => {
+						let label = window.label().to_string();
+						log::info!("window {} closed, stopping its sidecar", label);
+						let state = window.app_handle().state::<bridge::BridgeState>();
+						bridge::kill_sidecar_for_window(state.inner(), &label);
+					}
+					WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) => {
+						let paths: Vec<String> = paths
+							.iter()
+							.map(|path| path.to_string_lossy().to_string())
+							.collect();
+						bridge::log_file(&format!("native_file_drop: {:?}", paths));
+						let _ = window.emit("native_file_drop", serde_json::json!({ "paths": paths }));
+					}
+					_ => {}
+				}
+			})
 		.run(tauri::generate_context!())
 		.expect("error while running tauri application");
 }

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -14,16 +14,16 @@ fn main() {
 		.invoke_handler(tauri::generate_handler![
 			bridge::init_sidecar,
 			bridge::stop_sidecar,
-				bridge::rpc_command,
-				bridge::new_workspace,
-				bridge::list_workspaces,
-				bridge::delete_workspace,
-				bridge::reveal_workspace,
-				bridge::reveal_file,
-				bridge::describe_dropped_files,
-				bridge::save_upload,
-				bridge::list_providers,
-				bridge::set_provider_api_key,
+			bridge::rpc_command,
+			bridge::new_workspace,
+			bridge::list_workspaces,
+			bridge::delete_workspace,
+			bridge::reveal_workspace,
+			bridge::reveal_file,
+			bridge::describe_dropped_files,
+			bridge::save_upload,
+			bridge::list_providers,
+			bridge::set_provider_api_key,
 			bridge::remove_provider_api_key,
 			bridge::restart_sidecar,
 			bridge::set_window_background,
@@ -44,25 +44,23 @@ fn main() {
 			}
 			Ok(())
 		})
-			.on_window_event(|window, event| {
-				match event {
-					WindowEvent::CloseRequested { .. } => {
-						let label = window.label().to_string();
-						log::info!("window {} closed, stopping its sidecar", label);
-						let state = window.app_handle().state::<bridge::BridgeState>();
-						bridge::kill_sidecar_for_window(state.inner(), &label);
-					}
-					WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) => {
-						let paths: Vec<String> = paths
-							.iter()
-							.map(|path| path.to_string_lossy().to_string())
-							.collect();
-						bridge::log_file(&format!("native_file_drop: {:?}", paths));
-						let _ = window.emit("native_file_drop", serde_json::json!({ "paths": paths }));
-					}
-					_ => {}
-				}
-			})
+		.on_window_event(|window, event| match event {
+			WindowEvent::CloseRequested { .. } => {
+				let label = window.label().to_string();
+				log::info!("window {} closed, stopping its sidecar", label);
+				let state = window.app_handle().state::<bridge::BridgeState>();
+				bridge::kill_sidecar_for_window(state.inner(), &label);
+			}
+			WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) => {
+				let paths: Vec<String> = paths
+					.iter()
+					.map(|path| path.to_string_lossy().to_string())
+					.collect();
+				bridge::log_file(&format!("native_file_drop: {:?}", paths));
+				let _ = window.emit("native_file_drop", serde_json::json!({ "paths": paths }));
+			}
+			_ => {}
+		})
 		.run(tauri::generate_context!())
 		.expect("error while running tauri application");
 }

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -24,6 +24,7 @@
 				"minWidth": 720,
 				"minHeight": 480,
 				"resizable": true,
+				"dragDropEnabled": false,
 				"titleBarStyle": "Overlay",
 				"hiddenTitle": true,
 				"trafficLightPosition": {

--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -8,7 +8,8 @@ import {
 	type LoadedFileAttachment,
 	type RejectedAttachment,
 } from "@/lib/file-attachment";
-import { FileAttachmentIcon, formatFileSize } from "@/components/FileAttachmentIcon";
+import { FileAttachmentIcon } from "@/components/FileAttachmentIcon";
+import { formatFileSize } from "@/lib/file-format";
 
 export type { LoadedFileAttachment } from "@/lib/file-attachment";
 import { sendCommandAwait, setSafeMode, newSession, getSkills, invoke, type SkillInfo } from "@/lib/transport";

--- a/apps/web/src/components/Composer.tsx
+++ b/apps/web/src/components/Composer.tsx
@@ -4,9 +4,11 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import {
 	loadFileAttachment,
+	loadPathAttachments,
 	type LoadedFileAttachment,
 	type RejectedAttachment,
 } from "@/lib/file-attachment";
+import { FileAttachmentIcon, formatFileSize } from "@/components/FileAttachmentIcon";
 
 export type { LoadedFileAttachment } from "@/lib/file-attachment";
 import { sendCommandAwait, setSafeMode, newSession, getSkills, invoke, type SkillInfo } from "@/lib/transport";
@@ -21,58 +23,6 @@ function formatTokens(n: number): string {
 	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
 	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
 	return `${n}`;
-}
-
-/** Format a byte count as a compact human-readable string (e.g. 1.2k, 3.4M). */
-function formatFileSize(bytes: number): string {
-	if (bytes <= 0) return "";
-	if (bytes < 1024) return `${bytes} B`;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
-	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
-}
-
-/**
- * Map a filename or MIME type to a small icon hint. We render a tiny
- * 2-letter ext badge since lucide has no built-in file-type icons.
- */
-const FILE_TYPE_TINTS: { match: RegExp; label: string; tone: string }[] = [
-	{ match: /^image\//, label: "IMG", tone: "bg-violet-500/15 text-violet-300" },
-	{ match: /\.(png|jpe?g|gif|webp|svg|bmp|heic|avif)$/i, label: "IMG", tone: "bg-violet-500/15 text-violet-300" },
-	{ match: /\.(docx?|doc)$/i, label: "DOC", tone: "bg-blue-500/15 text-blue-300" },
-	{ match: /\.(pdf)$/i, label: "PDF", tone: "bg-red-500/15 text-red-300" },
-	{ match: /\.(xlsx?|csv|xls)$/i, label: "XLS", tone: "bg-green-500/15 text-green-300" },
-	{ match: /\.(pptx?|ppt)$/i, label: "PPT", tone: "bg-orange-500/15 text-orange-300" },
-	{ match: /\.(zip|7z|rar|tar|gz|bz2|xz)$/i, label: "ZIP", tone: "bg-yellow-500/15 text-yellow-300" },
-	{ match: /\.(ts|tsx|js|jsx|mjs|cjs|json)$/i, label: "JS", tone: "bg-amber-500/15 text-amber-300" },
-	{ match: /\.(py|ipynb)$/i, label: "PY", tone: "bg-emerald-500/15 text-emerald-300" },
-	{ match: /\.(md|markdown|mdx)$/i, label: "MD", tone: "bg-slate-500/15 text-slate-300" },
-	{ match: /\.(html?|css|scss|sass|less)$/i, label: "WEB", tone: "bg-orange-500/15 text-orange-300" },
-	{ match: /\.(sh|bash|zsh|fish|ps1)$/i, label: "SH", tone: "bg-zinc-500/15 text-zinc-300" },
-	{ match: /\.(rs|go|java|kt|swift|c|cc|cpp|cxx|h|hpp|rb|py|ts)$/i, label: "CODE", tone: "bg-sky-500/15 text-sky-300" },
-	{ match: /\.(txt|log|md)$/i, label: "TXT", tone: "bg-zinc-500/15 text-zinc-300" },
-];
-
-/**
- * Small uppercase file-type badge for the file chip. Renders a 2-3 letter
- * label (IMG, PDF, DOC, ZIP, etc.) tinted by category. We intentionally avoid
- * pulling in a many-kg file-type icon library — the badge is enough to
- * distinguish the major categories at a glance.
- */
-function FileIcon({ name, mimeType }: { name: string; mimeType?: string }) {
-	const pick = FILE_TYPE_TINTS.find((t) =>
-		(t.match.test(name) || (mimeType && t.match.test(mimeType))) ? true : false,
-	) ?? FILE_TYPE_TINTS[FILE_TYPE_TINTS.length - 1];
-	const label = pick.label;
-	const tone = pick.tone;
-	return (
-		<div
-			className={`flex h-6 w-6 shrink-0 items-center justify-center rounded text-[10px] font-semibold uppercase tracking-wide ${tone}`}
-			title={mimeType || name}
-		>
-			{label}
-		</div>
-	);
 }
 
 /** Small circular progress ring showing context window usage. */
@@ -569,33 +519,102 @@ ${insert}`;
 	}, []);
 
 	const addFiles = useCallback(async (files: FileList | File[]) => {
-	// Every dropped/picked file ends up under the workspace's per-session
-	// uploads directory. Image attachments stay as base64 inline attachments
-	// (the LLM needs to see the pixels); anything else becomes a path
-	// reference the agent can read back with its own file tools.
-	const list = Array.from(files);
-	const results = await Promise.all(list.map(loadFileAttachment));
-	const nextImages: ComposerImage[] = [];
-	const nextFiles: LoadedFileAttachment[] = [];
-	const nextRejected: RejectedAttachment[] = [];
-	for (const r of results) {
-		if (r.kind === "image") {
-			nextImages.push({
-				data: r.data,
-				mimeType: r.mimeType,
-				name: r.name,
-				preview: r.preview,
-			});
-		} else if (r.kind === "file") {
-			nextFiles.push(r);
-		} else {
-			nextRejected.push(r);
+		// Image attachments stay as base64 inline attachments; anything else
+		// becomes a path reference the agent can read back with its file tools.
+		const list = Array.from(files);
+		const results = await Promise.all(list.map(loadFileAttachment));
+		const nextImages: ComposerImage[] = [];
+		const nextFiles: LoadedFileAttachment[] = [];
+		const nextRejected: RejectedAttachment[] = [];
+		for (const r of results) {
+			if (r.kind === "image") {
+				nextImages.push({
+					data: r.data,
+					mimeType: r.mimeType,
+					name: r.name,
+					preview: r.preview,
+				});
+			} else if (r.kind === "file") {
+				nextFiles.push(r);
+			} else {
+				nextRejected.push(r);
+			}
 		}
-	}
-	if (nextImages.length > 0) setImages((prev) => [...prev, ...nextImages]);
-	if (nextFiles.length > 0) setFiles((prev) => [...prev, ...nextFiles]);
-	if (nextRejected.length > 0) setRejected((prev) => [...prev, ...nextRejected]);
-}, []);;
+		if (nextImages.length > 0) setImages((prev) => [...prev, ...nextImages]);
+		if (nextFiles.length > 0) setFiles((prev) => [...prev, ...nextFiles]);
+		if (nextRejected.length > 0) setRejected((prev) => [...prev, ...nextRejected]);
+	}, []);
+
+	const addPathFiles = useCallback(async (paths: string[]) => {
+		const uniquePaths = Array.from(new Set(paths.filter(Boolean)));
+		if (uniquePaths.length === 0) return;
+		try {
+			const nextFiles = await loadPathAttachments(uniquePaths);
+			if (nextFiles.length > 0) {
+				setFiles((prev) => {
+					const seen = new Set(prev.map((file) => file.absolutePath));
+					return [
+						...prev,
+						...nextFiles.filter((file) => {
+							if (seen.has(file.absolutePath)) return false;
+							seen.add(file.absolutePath);
+							return true;
+						}),
+					];
+				});
+			}
+		} catch (e) {
+			setRejected((prev) => [
+				...prev,
+				{
+					kind: "rejected",
+					name: uniquePaths.length === 1 ? uniquePaths[0] : `${uniquePaths.length} files`,
+					size: 0,
+					mimeType: "",
+					reason: e instanceof Error ? e.message : String(e),
+				},
+			]);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (!sidecarReady || !isTauri()) return;
+		let cancelled = false;
+		let unlisten: (() => void) | undefined;
+		let unlistenNative: (() => void) | undefined;
+		void (async () => {
+			const { listen } = await import("@tauri-apps/api/event");
+			unlistenNative = await listen<{ paths?: string[] }>("native_file_drop", (event) => {
+				if (cancelled) return;
+				setIsDragOver(false);
+				void addPathFiles(event.payload.paths ?? []);
+			});
+			const { getCurrentWebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+			unlisten = await getCurrentWebviewWindow().onDragDropEvent((event) => {
+				if (cancelled) return;
+				const payload = event.payload as { type?: string; paths?: string[] };
+				if (payload.type === "enter" || payload.type === "over") {
+					setIsDragOver(true);
+					return;
+				}
+				if (payload.type === "leave") {
+					setIsDragOver(false);
+					return;
+				}
+				if (payload.type === "drop") {
+					setIsDragOver(false);
+					void addPathFiles(payload.paths ?? []);
+				}
+			});
+		})().catch((e) => {
+			console.error("[composer] tauri drag-drop listener failed:", e);
+		});
+		return () => {
+			cancelled = true;
+			unlisten?.();
+			unlistenNative?.();
+		};
+	}, [sidecarReady, addPathFiles]);
 
 	// --- Drag-and-drop wiring ----------------------------------------------
 	// We listen on the outer composer wrapper (not the textarea) so users can
@@ -728,7 +747,7 @@ ${insert}`;
 							</div>
 						</div>
 					)}
-					{images.length > 0 && (
+					{(images.length > 0 || files.length > 0) && (
 						<div className="mb-2 flex flex-wrap gap-2">
 							{images.map((img, i) => (
 								<div
@@ -750,38 +769,38 @@ ${insert}`;
 									</button>
 								</div>
 							))}
-						{files.map((f, i) => (
-							<div
-								key={f.absolutePath}
-								className="group flex h-9 w-48 items-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-2 px-2.5 text-xs"
-								title={f.absolutePath}
-							>
-								<FileIcon name={f.name} mimeType={f.mimeType} />
-								<div className="flex min-w-0 flex-1 flex-col">
-									<span className="truncate text-fg">{f.name}</span>
-									{f.size > 0 && (
-										<span className="truncate text-[10px] text-muted">{formatFileSize(f.size)}</span>
-									)}
-								</div>
-								<button
-									type="button"
-									onClick={() => revealInFinder(f.absolutePath)}
-									className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted transition-colors hover:bg-bg/60 hover:text-fg"
-									title={t("composer.revealInFinder")}
+							{files.map((f, i) => (
+								<div
+									key={f.absolutePath}
+									className="group flex h-9 w-48 items-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-2 px-2.5 text-xs"
+									title={f.absolutePath}
+								>
+									<FileAttachmentIcon name={f.name} mimeType={f.mimeType} />
+									<div className="flex min-w-0 flex-1 flex-col">
+										<span className="truncate text-fg">{f.name}</span>
+										{f.size > 0 && (
+											<span className="truncate text-[10px] text-muted">{formatFileSize(f.size)}</span>
+										)}
+									</div>
+									<button
+										type="button"
+										onClick={() => revealInFinder(f.absolutePath)}
+										className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted transition-colors hover:bg-bg/60 hover:text-fg"
+										title={t("composer.revealInFinder")}
 									>
 										<FolderOpen className="h-3.5 w-3.5" />
 									</button>
-								<button
-									type="button"
-									onClick={() => removeFile(i)}
-									className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted transition-colors hover:bg-bg/60 hover:text-fg"
-									title={t("common.remove")}
+									<button
+										type="button"
+										onClick={() => removeFile(i)}
+										className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted transition-colors hover:bg-bg/60 hover:text-fg"
+										title={t("common.remove")}
 									>
 										<X className="h-3.5 w-3.5" />
 									</button>
-							</div>
-						))}
-					</div>
+								</div>
+							))}
+						</div>
 					)}
 					{rejected.length > 0 && (
 						<div className="mb-2 rounded-lg border border-warning/40 bg-warning/5 px-3 py-2 text-xs text-warning">
@@ -834,12 +853,10 @@ ${insert}`;
 					<div className="mt-1 flex items-center justify-between gap-2">
 						{/* Left cluster */}
 						<div className="flex items-center gap-1">
-
-						{/* + button: multi-action menu (new session, attach, skills) */}
+							{/* + button: multi-action menu (new session, attach, skills) */}
 							<input
 								ref={fileInputRef}
 								type="file"
-								accept="image/*"
 								multiple
 								className="hidden"
 								onChange={handleFileChange}

--- a/apps/web/src/components/Conversation.tsx
+++ b/apps/web/src/components/Conversation.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./Markdown";
 import { Button, Badge } from "@/components/ui";
+import { FileAttachmentIcon, formatFileSize } from "@/components/FileAttachmentIcon";
 import {
 	Terminal,
 	ChevronRight,
@@ -61,15 +62,6 @@ function formatMessageTime(ts?: number): string {
 	} catch {
 		return "";
 	}
-}
-
-/** Compact human-readable byte count (e.g. 1.2 kB, 3.4 MB). */
-function formatFileSize(bytes: number): string {
-	if (bytes <= 0) return "";
-	if (bytes < 1024) return `${bytes} B`;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
-	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
 
 const COLLAPSE_LINES = 5;
@@ -380,9 +372,7 @@ function UserBubble({ item }: { item: TimelineItem }) {
 								className="flex h-9 w-48 items-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-2 px-2.5 text-xs"
 								title={f.absolutePath}
 							>
-								<div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[10px] font-semibold uppercase tracking-wide bg-slate-500/15 text-slate-300">
-									{f.name.split(".").pop()?.toUpperCase().slice(0, 3) ?? "FILE"}
-								</div>
+								<FileAttachmentIcon name={f.name} mimeType={f.mimeType} />
 								<div className="flex min-w-0 flex-1 flex-col">
 									<span className="truncate text-fg">{f.name}</span>
 									{f.size > 0 && (
@@ -481,9 +471,7 @@ function AssistantMessage({ item }: { item: TimelineItem }) {
 								className="flex h-9 w-48 items-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-2 px-2.5 text-xs"
 								title={f.absolutePath}
 							>
-								<div className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[10px] font-semibold uppercase tracking-wide bg-slate-500/15 text-slate-300">
-									{f.name.split(".").pop()?.toUpperCase().slice(0, 3) ?? "FILE"}
-								</div>
+								<FileAttachmentIcon name={f.name} mimeType={f.mimeType} />
 								<div className="flex min-w-0 flex-1 flex-col">
 									<span className="truncate text-fg">{f.name}</span>
 									{f.size > 0 && (

--- a/apps/web/src/components/Conversation.tsx
+++ b/apps/web/src/components/Conversation.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./Markdown";
 import { Button, Badge } from "@/components/ui";
-import { FileAttachmentIcon, formatFileSize } from "@/components/FileAttachmentIcon";
+import { FileAttachmentIcon } from "@/components/FileAttachmentIcon";
+import { formatFileSize } from "@/lib/file-format";
 import {
 	Terminal,
 	ChevronRight,
@@ -366,7 +367,7 @@ function UserBubble({ item }: { item: TimelineItem }) {
 				)}
 				{item.files && item.files.length > 0 && (
 					<div className="mb-2 flex flex-wrap gap-2">
-						{item.files.map((f, i) => (
+						{item.files.map((f) => (
 							<div
 								key={f.absolutePath}
 								className="flex h-9 w-48 items-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-2 px-2.5 text-xs"
@@ -465,7 +466,7 @@ function AssistantMessage({ item }: { item: TimelineItem }) {
 				)}
 				{item.files && item.files.length > 0 && (
 					<div className="mb-2 flex flex-wrap gap-2">
-						{item.files.map((f, i) => (
+						{item.files.map((f) => (
 							<div
 								key={f.absolutePath}
 								className="flex h-9 w-48 items-center gap-2 overflow-hidden rounded-lg border border-border bg-surface-2 px-2.5 text-xs"

--- a/apps/web/src/components/FileAttachmentIcon.tsx
+++ b/apps/web/src/components/FileAttachmentIcon.tsx
@@ -1,14 +1,5 @@
 import { cn } from "@/lib/utils";
 
-/** Compact human-readable byte count (e.g. 1.2 kB, 3.4 MB). */
-export function formatFileSize(bytes: number): string {
-	if (bytes <= 0) return "";
-	if (bytes < 1024) return `${bytes} B`;
-	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
-	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
-}
-
 const FILE_TYPE_TONES: { match: RegExp; label: string; tone: string }[] = [
 	{ match: /^image\//i, label: "IMG", tone: "border-violet-300 bg-violet-100 text-violet-800 dark:border-violet-700 dark:bg-violet-950/70 dark:text-violet-100" },
 	{ match: /\.(png|jpe?g|gif|webp|svg|bmp|heic|avif)$/i, label: "IMG", tone: "border-violet-300 bg-violet-100 text-violet-800 dark:border-violet-700 dark:bg-violet-950/70 dark:text-violet-100" },

--- a/apps/web/src/components/FileAttachmentIcon.tsx
+++ b/apps/web/src/components/FileAttachmentIcon.tsx
@@ -1,0 +1,60 @@
+import { cn } from "@/lib/utils";
+
+/** Compact human-readable byte count (e.g. 1.2 kB, 3.4 MB). */
+export function formatFileSize(bytes: number): string {
+	if (bytes <= 0) return "";
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+const FILE_TYPE_TONES: { match: RegExp; label: string; tone: string }[] = [
+	{ match: /^image\//i, label: "IMG", tone: "border-violet-300 bg-violet-100 text-violet-800 dark:border-violet-700 dark:bg-violet-950/70 dark:text-violet-100" },
+	{ match: /\.(png|jpe?g|gif|webp|svg|bmp|heic|avif)$/i, label: "IMG", tone: "border-violet-300 bg-violet-100 text-violet-800 dark:border-violet-700 dark:bg-violet-950/70 dark:text-violet-100" },
+	{ match: /\.(pdf)$/i, label: "PDF", tone: "border-red-300 bg-red-100 text-red-800 dark:border-red-700 dark:bg-red-950/70 dark:text-red-100" },
+	{ match: /\.(docx?|doc)$/i, label: "DOC", tone: "border-blue-300 bg-blue-100 text-blue-800 dark:border-blue-700 dark:bg-blue-950/70 dark:text-blue-100" },
+	{ match: /\.(xlsx?|csv|xls)$/i, label: "XLS", tone: "border-green-300 bg-green-100 text-green-800 dark:border-green-700 dark:bg-green-950/70 dark:text-green-100" },
+	{ match: /\.(pptx?|ppt)$/i, label: "PPT", tone: "border-orange-300 bg-orange-100 text-orange-900 dark:border-orange-700 dark:bg-orange-950/70 dark:text-orange-100" },
+	{ match: /\.(zip|7z|rar|tar|gz|bz2|xz)$/i, label: "ZIP", tone: "border-yellow-300 bg-yellow-100 text-yellow-900 dark:border-yellow-700 dark:bg-yellow-950/70 dark:text-yellow-100" },
+	{ match: /\.(md|markdown|mdx)$/i, label: "MD", tone: "border-slate-300 bg-slate-100 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100" },
+	{ match: /\.(txt|log)$/i, label: "TXT", tone: "border-slate-300 bg-slate-100 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100" },
+	{ match: /\.(ts|tsx|js|jsx|mjs|cjs|json)$/i, label: "JS", tone: "border-amber-300 bg-amber-100 text-amber-900 dark:border-amber-700 dark:bg-amber-950/70 dark:text-amber-100" },
+	{ match: /\.(py|ipynb)$/i, label: "PY", tone: "border-emerald-300 bg-emerald-100 text-emerald-900 dark:border-emerald-700 dark:bg-emerald-950/70 dark:text-emerald-100" },
+	{ match: /\.(html?|css|scss|sass|less)$/i, label: "WEB", tone: "border-orange-300 bg-orange-100 text-orange-900 dark:border-orange-700 dark:bg-orange-950/70 dark:text-orange-100" },
+	{ match: /\.(sh|bash|zsh|fish|ps1)$/i, label: "SH", tone: "border-zinc-300 bg-zinc-100 text-zinc-800 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-100" },
+	{ match: /\.(rs|go|java|kt|swift|c|cc|cpp|cxx|h|hpp|rb)$/i, label: "CODE", tone: "border-sky-300 bg-sky-100 text-sky-800 dark:border-sky-700 dark:bg-sky-950/70 dark:text-sky-100" },
+];
+
+function fileTone(name: string, mimeType?: string) {
+	const haystack = `${name}\n${mimeType ?? ""}`;
+	return FILE_TYPE_TONES.find((t) => t.match.test(haystack)) ?? {
+		label: (name.split(".").pop() || "FILE").toUpperCase().slice(0, 4),
+		tone: "border-stone-300 bg-stone-100 text-stone-800 dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100",
+	};
+}
+
+export function FileAttachmentIcon({
+	name,
+	mimeType,
+	className,
+}: {
+	name: string;
+	mimeType?: string;
+	className?: string;
+}) {
+	const pick = fileTone(name, mimeType);
+	return (
+		<div
+			className={cn(
+				"relative flex h-7 w-7 shrink-0 items-center justify-center rounded-md border text-[9px] font-bold uppercase leading-none shadow-[inset_0_1px_0_rgba(255,255,255,0.65)]",
+				pick.tone,
+				className,
+			)}
+			title={mimeType || name}
+		>
+			<span className="pointer-events-none absolute right-0 top-0 h-2 w-2 rounded-bl border-b border-l border-current/20 bg-white/45 dark:bg-white/10" />
+			<span className="relative z-10 max-w-full truncate px-0.5">{pick.label}</span>
+		</div>
+	);
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -83,9 +83,8 @@
     "skills": "Skills",
     "revealInFinder": "Show in file manager",
     "dropFiles": "Drop files to attach",
-    "rejectedFiles_one": "1 file was skipped",
-    "rejectedFiles_other": "{{count}} files were skipped"
-    "skills": "Skills",
+		"rejectedFiles_one": "1 file was skipped",
+		"rejectedFiles_other": "{{count}} files were skipped",
     "scheduledTask": "Scheduled task",
     "scheduledTaskHint": "Run a task automatically at the right time"
   },

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -83,9 +83,8 @@
     "skills": "技能",
     "revealInFinder": "在文件管理器中显示",
     "dropFiles": "拖入文件以附加",
-    "rejectedFiles_one": "已跳过 1 个文件",
-    "rejectedFiles_other": "已跳过 {{count}} 个文件"
-    "skills": "技能",
+		"rejectedFiles_one": "已跳过 1 个文件",
+		"rejectedFiles_other": "已跳过 {{count}} 个文件",
     "scheduledTask": "定时任务",
     "scheduledTaskHint": "在指定时间自动执行任务"
   },

--- a/apps/web/src/lib/file-attachment.ts
+++ b/apps/web/src/lib/file-attachment.ts
@@ -15,6 +15,15 @@
 
 import { sendCommandAwait } from "./transport";
 
+function isTauri(): boolean {
+	return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+async function invokeTauri<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+	const { invoke } = await import("@tauri-apps/api/core");
+	return invoke<T>(command, args);
+}
+
 /** Hard upper bound for image attachments; the sidecar / image-resize path
  *  handles anything under this.  */
 export const MAX_IMAGE_BYTES = 2000 * 2000 * 4;
@@ -71,6 +80,17 @@ export interface RejectedAttachment {
 
 export type LoadedAttachment = LoadedImageAttachment | LoadedFileAttachment;
 export type AnyAttachment = LoadedAttachment | RejectedAttachment;
+
+type NativeFileAttachment = Omit<LoadedFileAttachment, "kind"> & { kind?: "file" };
+
+export async function loadPathAttachments(paths: string[]): Promise<LoadedFileAttachment[]> {
+	if (!isTauri() || paths.length === 0) return [];
+	const files = await invokeTauri<NativeFileAttachment[]>("describe_dropped_files", { paths });
+	return files.map((file) => ({
+		...file,
+		kind: "file",
+	}));
+}
 
 // ---------------------------------------------------------------------------
 // FileReader helpers — browser/DOM only.
@@ -171,34 +191,41 @@ export async function loadFileAttachment(file: File): Promise<AnyAttachment> {
 		};
 	}
 
-	try {
-		const r = await sendCommandAwait<{
-			absolutePath: string;
-			relativePath: string;
-			size: number;
-		}>({
-			type: "save_upload",
-			filename: name,
-			mimeType: declaredMime || "application/octet-stream",
-			dataB64,
-		}, 120_000);
-		if (!r.data) {
+		try {
+			const uploaded = isTauri()
+				? await invokeTauri<NativeFileAttachment>("save_upload", {
+						filename: name,
+						mimeType: declaredMime || "application/octet-stream",
+						dataB64,
+					})
+				: (await sendCommandAwait<{
+						absolutePath: string;
+						relativePath: string;
+						mimeType?: string;
+						size: number;
+					}>({
+						type: "save_upload",
+						filename: name,
+						mimeType: declaredMime || "application/octet-stream",
+						dataB64,
+					}, 120_000)).data;
+			if (!uploaded) {
+				return {
+					kind: "rejected",
+					name,
+					size,
+					mimeType: declaredMime,
+					reason: "Server returned an empty response",
+				};
+			}
 			return {
-				kind: "rejected",
+				kind: "file",
+				absolutePath: uploaded.absolutePath,
+				relativePath: uploaded.relativePath,
+				mimeType: uploaded.mimeType ?? (declaredMime || "application/octet-stream"),
 				name,
-				size,
-				mimeType: declaredMime,
-				reason: "Server returned an empty response",
+				size: uploaded.size,
 			};
-		}
-		return {
-			kind: "file",
-			absolutePath: r.data.absolutePath,
-			relativePath: r.data.relativePath,
-			mimeType: declaredMime || "application/octet-stream",
-			name,
-			size: r.data.size,
-		};
 	} catch (e) {
 		return {
 			kind: "rejected",

--- a/apps/web/src/lib/file-format.ts
+++ b/apps/web/src/lib/file-format.ts
@@ -1,0 +1,8 @@
+/** Compact human-readable byte count (e.g. 1.2 kB, 3.4 MB). */
+export function formatFileSize(bytes: number): string {
+	if (bytes <= 0) return "";
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}

--- a/apps/web/src/views/BranchTreeExplorer.tsx
+++ b/apps/web/src/views/BranchTreeExplorer.tsx
@@ -222,49 +222,18 @@ export default function BranchTreeExplorer({ workspace }: { workspace?: string |
 
 			{/* Context menu */}
 			{menu && (
-				<div
-					className="fixed z-50 min-w-52 rounded-md border border-border bg-surface-2 py-1 shadow-lg"
-					style={{ left: menu.x, top: menu.y }}
-					onMouseDown={(e) => e.stopPropagation()}
-				>
-					{/* Switch only moves the active pointer. Jump keeps the existing
-						"reopen closed branches by forking" behavior. */}
-					<MenuItem
-						icon={LogIn}
-						label={t("history.switchHere")}
-						hint={menu.node.closed ? t("history.switchClosedHint") : t("history.switchOpenHint")}
-						disabled={menu.node.is_active}
-						onClick={() => void onSwitch(menu.node)}
-					/>
-					<MenuItem
-						icon={CornerUpRight}
-						label={t("history.jumpHere")}
-						hint={
-							menu.node.is_active
-								? undefined
-								: menu.node.closed
-									? t("history.jumpClosedHint")
-									: t("history.jumpOpenHint")
-						}
-						disabled={menu.node.is_active}
-						onClick={() => void onJump(menu.node)}
-					/>
-					{/* Fork always creates a new child branch; if the source is open
-						and at HEAD, it gets frozen at the fork point. */}
-					<MenuItem
-						icon={GitFork}
-						label={t("history.forkFromHere")}
-						hint={t("history.forkHint")}
-						onClick={() => void onFork(menu.node)}
-					/>
-					<MenuItem icon={Pencil} label={t("history.rename")} onClick={() => void onRename(menu.node)} />
-					<div className="my-1 h-px bg-border" />
-					<MenuItem
-						icon={Copy}
-						label={t("history.copyId")}
-						onClick={() => { void navigator.clipboard?.writeText(menu.node.session_id); setMenu(null); }}
-					/>
-				</div>
+				<ContextMenu
+					x={menu.x}
+					y={menu.y}
+					onDismiss={() => setMenu(null)}
+					items={buildHistoryMenuItems(menu.node, t, {
+						onSwitch: () => void onSwitch(menu.node),
+						onJump: () => void onJump(menu.node),
+						onFork: () => void onFork(menu.node),
+						onRename: () => void onRename(menu.node),
+						onCopyId: () => void navigator.clipboard?.writeText(menu.node.session_id),
+					})}
+				/>
 			)}
 		</div>
 	);
@@ -273,9 +242,16 @@ export default function BranchTreeExplorer({ workspace }: { workspace?: string |
 function buildHistoryMenuItems(
 	node: RpcHistoryTreeNode,
 	t: (k: string) => string,
-	handlers: { onJump: () => void; onFork: () => void; onRename: () => void; onCopyId: () => void },
+	handlers: { onSwitch: () => void; onJump: () => void; onFork: () => void; onRename: () => void; onCopyId: () => void },
 ): ContextMenuItem[] {
 	return [
+		{
+			icon: LogIn,
+			label: t("history.switchHere"),
+			hint: node.closed ? t("history.switchClosedHint") : t("history.switchOpenHint"),
+			disabled: node.is_active,
+			onClick: handlers.onSwitch,
+		},
 		{
 			icon: CornerUpRight,
 			label: t("history.jumpHere"),

--- a/apps/web/src/views/ChatView.tsx
+++ b/apps/web/src/views/ChatView.tsx
@@ -83,17 +83,36 @@ function messageFiles(message: unknown): Array<{
 }> {
 	if (!message || typeof message !== "object") return [];
 	const msg = message as Record<string, unknown>;
-	if (!Array.isArray(msg.files)) return [];
 	const out: Array<{ absolutePath: string; mimeType: string; name: string; size: number }> = [];
-	for (const f of msg.files as Array<Record<string, unknown>>) {
-		if (!f || typeof f !== "object") continue;
-		const absolutePath = typeof f.absolutePath === "string" ? f.absolutePath : "";
-		const name = typeof f.name === "string" ? f.name : absolutePath.split("/").pop() ?? "file";
-		const mimeType = typeof f.mimeType === "string" ? f.mimeType : "";
-		const size = typeof f.size === "number" ? f.size : 0;
-		if (absolutePath) out.push({ absolutePath, mimeType, name, size });
+	if (Array.isArray(msg.files)) {
+		for (const f of msg.files as Array<Record<string, unknown>>) {
+			if (!f || typeof f !== "object") continue;
+			const absolutePath = typeof f.absolutePath === "string" ? f.absolutePath : "";
+			const name = typeof f.name === "string" ? f.name : absolutePath.split("/").pop() ?? "file";
+			const mimeType = typeof f.mimeType === "string" ? f.mimeType : "";
+			const size = typeof f.size === "number" ? f.size : 0;
+			if (absolutePath) out.push({ absolutePath, mimeType, name, size });
+		}
+	}
+	const content = typeof msg.content === "string" ? msg.content : "";
+	for (const match of content.matchAll(/<file\s+path="([^"]+)"\s*\/?>/g)) {
+		const absolutePath = match[1];
+		if (!absolutePath || out.some((file) => file.absolutePath === absolutePath)) continue;
+		out.push({
+			absolutePath,
+			mimeType: "",
+			name: absolutePath.split("/").pop() ?? "file",
+			size: 0,
+		});
 	}
 	return out;
+}
+
+function hideFileRefs(text: string): string {
+	return text
+		.replace(/^\s*<file\s+path="[^"]+"\s*\/?>\s*$/gm, "")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
 }
 
 /** Extract toolCall blocks (id, name, JSON args) from an assistant message. */
@@ -144,7 +163,7 @@ function messageThinking(message: unknown): string {
 function messageText(message: unknown): string {
 	if (!message || typeof message !== "object") return "";
 	const msg = message as Record<string, unknown>;
-	if (typeof msg.content === "string") return msg.content;
+	if (typeof msg.content === "string") return hideFileRefs(msg.content);
 	if (Array.isArray(msg.content)) {
 		return (msg.content as Array<Record<string, unknown>>)
 			.map((block) => {

--- a/packages/rpc/rpc-mode.ts
+++ b/packages/rpc/rpc-mode.ts
@@ -187,9 +187,16 @@ function extensionIdFromPath(extPath: string): string {
  * it against `descriptor.workspace_id` (which is the hash).
  */
 function canonicalWorkspaceId(cwd: string): string {
+	if (/^ws_[0-9a-f]{12}$/.test(cwd)) return cwd;
 	const { resolve } = require("node:path") as typeof import("node:path");
 	const canonical = resolve(cwd).replace(/\\/g, "/");
 	return `ws_${require("node:crypto").createHash("sha256").update(canonical).digest("hex").slice(0, 12)}`;
+}
+
+function workspaceIdMatches(provided: string | undefined, expected: string | undefined): boolean {
+	if (provided === expected) return true;
+	if (!provided || !expected) return false;
+	return canonicalWorkspaceId(provided) === canonicalWorkspaceId(expected);
 }
 
 /** Map a loaded extension's sourceInfo/path to the RPC kind. */
@@ -1089,9 +1096,8 @@ export async function runRpcModeWithFacade(facade: SessionFacade): Promise<never
 					return error(id, "schedule_create", `Scope mismatch: sidecar is ${schedulerScope}, task is ${t.scope}`);
 				}
 				if (t.scope === "workspace") {
-					const provided = t.workspaceId ? canonicalWorkspaceId(t.workspaceId) : undefined;
-					if (provided !== schedulerWorkspaceId) {
-						return error(id, "schedule_create", `Workspace mismatch: sidecar is ${schedulerWorkspaceId}, task is ${provided} (from ${t.workspaceId})`);
+					if (!workspaceIdMatches(t.workspaceId, schedulerWorkspaceId)) {
+						return error(id, "schedule_create", `Workspace mismatch: sidecar is ${schedulerWorkspaceId}, task is ${t.workspaceId}`);
 					}
 				}
 				const policy = facade.settingsManager.getSchedulerPolicy();
@@ -1120,8 +1126,7 @@ export async function runRpcModeWithFacade(facade: SessionFacade): Promise<never
 					return error(id, "schedule_update", `Scope mismatch`);
 				}
 				if (command.scope === "workspace") {
-					const provided = command.workspaceId ? canonicalWorkspaceId(command.workspaceId) : undefined;
-					if (provided !== schedulerWorkspaceId) {
+					if (!workspaceIdMatches(command.workspaceId, schedulerWorkspaceId)) {
 						return error(id, "schedule_update", `Workspace mismatch`);
 					}
 				}
@@ -1138,8 +1143,7 @@ export async function runRpcModeWithFacade(facade: SessionFacade): Promise<never
 					return error(id, "schedule_delete", `Scope mismatch`);
 				}
 				if (command.scope === "workspace") {
-					const provided = command.workspaceId ? canonicalWorkspaceId(command.workspaceId) : undefined;
-					if (provided !== schedulerWorkspaceId) {
+					if (!workspaceIdMatches(command.workspaceId, schedulerWorkspaceId)) {
 						return error(id, "schedule_delete", `Workspace mismatch`);
 					}
 				}
@@ -1153,8 +1157,7 @@ export async function runRpcModeWithFacade(facade: SessionFacade): Promise<never
 					return error(id, "schedule_run_now", `Scope mismatch`);
 				}
 				if (command.scope === "workspace") {
-					const provided = command.workspaceId ? canonicalWorkspaceId(command.workspaceId) : undefined;
-					if (provided !== schedulerWorkspaceId) {
+					if (!workspaceIdMatches(command.workspaceId, schedulerWorkspaceId)) {
 						return error(id, "schedule_run_now", `Workspace mismatch`);
 					}
 				}
@@ -1173,8 +1176,7 @@ export async function runRpcModeWithFacade(facade: SessionFacade): Promise<never
 					return error(id, "schedule_history", `Scope mismatch`);
 				}
 				if (command.scope === "workspace") {
-					const provided = command.workspaceId ? canonicalWorkspaceId(command.workspaceId) : undefined;
-					if (provided !== schedulerWorkspaceId) {
+					if (!workspaceIdMatches(command.workspaceId, schedulerWorkspaceId)) {
 						return error(id, "schedule_history", `Workspace mismatch`);
 					}
 				}

--- a/src/core/projection/session-manager.ts
+++ b/src/core/projection/session-manager.ts
@@ -186,8 +186,7 @@ export class SessionManager {
 
 		const forked = this.createSession("fork", source.name, {
 			parentSessionId: source.session_id,
-			contextParentSessionId: preserveHistory ? source.session_id : undefined,
-			startEventId: preserveHistory ? this.store.head ?? forkAtEventId : forkAtEventId,
+			startEventId: preserveHistory ? source.event_range.start_event_id : forkAtEventId,
 			summaryEventId: source.summary_event_id,
 			threadId: source.thread_id,
 		});

--- a/src/core/runtime/runtime.ts
+++ b/src/core/runtime/runtime.ts
@@ -198,7 +198,7 @@ export class EventSourcedRuntime {
 			this.store.append({
 				actor_id: "user",
 				type: "USER_MESSAGE",
-				payload: { content: text, images },
+				payload: { content: text, images, files },
 			});
 
 			await settledPromise;


### PR DESCRIPTION
## Summary
- restore desktop file drag-and-drop into the chat composer
- persist dragged and picked non-image files as readable upload references
- show attached files clearly in pending and sent messages with higher-contrast type badges
- keep file metadata visible when messages are reloaded from history
- fix the latest main build blockers encountered while packaging the desktop app

## Root Cause
File drops in the desktop app were not reliably reaching the web composer, and non-image attachments were not consistently saved or surfaced as file references. The file type badges also used very low-contrast colors, making TXT/PDF labels hard to read in the light theme.

## Validation
- `cd apps/web && npm run build`
- `npm run build:desktop`
- manual desktop drag test with a Finder TXT file into the Pizza composer
