### PR TITLE
fix(desktop): recover from main agent lock conflicts

### DIFF
--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -256,6 +256,15 @@ impl Default for BridgeState {
 	}
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MainAgentStatus {
+	running: bool,
+	pid: Option<u32>,
+	command: Option<String>,
+	lock_path: String,
+}
+
 /// Kill and remove the sidecar for a specific cwd.
 pub fn kill_sidecar_for_cwd(state: &BridgeState, cwd: &str) {
 	log_file(&format!("kill_sidecar_for_cwd: cwd={}", cwd));
@@ -365,6 +374,148 @@ fn is_persistent_chat_cwd(cwd: &str) -> bool {
 	persistent_chat_cwd()
 		.map(|main| normalize_path_for_compare(cwd) == normalize_path_for_compare(&main))
 		.unwrap_or(false)
+}
+
+fn main_agent_lock_path() -> Option<PathBuf> {
+	persistent_chat_cwd().map(|cwd| PathBuf::from(cwd).join(".lock"))
+}
+
+fn read_main_agent_lock_pid() -> Option<(PathBuf, u32)> {
+	let lock_path = main_agent_lock_path()?;
+	let raw = std::fs::read_to_string(&lock_path).ok()?;
+	let pid = raw.trim().parse::<u32>().ok()?;
+	Some((lock_path, pid))
+}
+
+#[cfg(unix)]
+fn is_process_alive(pid: u32) -> bool {
+	Command::new("kill")
+		.args(["-0", &pid.to_string()])
+		.status()
+		.map(|status| status.success())
+		.unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_process_alive(pid: u32) -> bool {
+	let pid_arg = pid.to_string();
+	Command::new("ps")
+		.args(["-p", &pid_arg])
+		.status()
+		.map(|status| status.success())
+		.unwrap_or(false)
+}
+
+fn process_command(pid: u32) -> Option<String> {
+	let pid_arg = pid.to_string();
+	let output = Command::new("ps")
+		.args(["-p", &pid_arg, "-o", "command="])
+		.output()
+		.ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let command = String::from_utf8_lossy(&output.stdout).trim().to_string();
+	if command.is_empty() {
+		None
+	} else {
+		Some(command)
+	}
+}
+
+fn is_probably_pizza_main_agent(command: &str) -> bool {
+	let lower = command.to_ascii_lowercase();
+	command.contains("--main")
+		&& (lower.contains("pizza")
+			|| lower.contains("src/cli")
+			|| lower.contains("src/main")
+			|| lower.contains("dist/cli")
+			|| lower.contains("dist/main"))
+}
+
+fn current_main_agent_status() -> MainAgentStatus {
+	let lock_path = main_agent_lock_path().unwrap_or_else(|| PathBuf::from("~/.pizza/main/.lock"));
+	let lock_path_str = lock_path.to_string_lossy().to_string();
+	let Some((_, pid)) = read_main_agent_lock_pid() else {
+		return MainAgentStatus {
+			running: false,
+			pid: None,
+			command: None,
+			lock_path: lock_path_str,
+		};
+	};
+	let running = is_process_alive(pid);
+	let command = if running { process_command(pid) } else { None };
+	MainAgentStatus {
+		running,
+		pid: Some(pid),
+		command,
+		lock_path: lock_path_str,
+	}
+}
+
+#[tauri::command]
+pub fn main_agent_status() -> Result<MainAgentStatus, String> {
+	Ok(current_main_agent_status())
+}
+
+#[tauri::command]
+pub async fn stop_main_agent() -> Result<MainAgentStatus, String> {
+	let Some((lock_path, pid)) = read_main_agent_lock_pid() else {
+		return Ok(current_main_agent_status());
+	};
+	if !is_process_alive(pid) {
+		let _ = std::fs::remove_file(&lock_path);
+		return Ok(current_main_agent_status());
+	}
+	let command = process_command(pid).unwrap_or_default();
+	if !is_probably_pizza_main_agent(&command) {
+		return Err(format!(
+			"锁文件指向的进程不像 Pizza 主助手，已停止自动处理。PID: {}，命令: {}",
+			pid,
+			if command.is_empty() {
+				"<unknown>"
+			} else {
+				&command
+			}
+		));
+	}
+
+	#[cfg(unix)]
+	let stop_result = Command::new("kill")
+		.args(["-TERM", &pid.to_string()])
+		.status()
+		.map(|status| status.success())
+		.unwrap_or(false);
+
+	#[cfg(not(unix))]
+	let stop_result = Command::new("taskkill")
+		.args(["/PID", &pid.to_string(), "/T"])
+		.status()
+		.map(|status| status.success())
+		.unwrap_or(false);
+
+	if !stop_result {
+		return Err(format!("无法停止旧主助手进程 PID {}", pid));
+	}
+
+	for _ in 0..30 {
+		if !is_process_alive(pid) {
+			if std::fs::read_to_string(&lock_path)
+				.map(|raw| raw.trim() == pid.to_string())
+				.unwrap_or(false)
+			{
+				let _ = std::fs::remove_file(&lock_path);
+			}
+			return Ok(current_main_agent_status());
+		}
+		tokio::time::sleep(Duration::from_millis(100)).await;
+	}
+
+	Err(format!(
+		"已请求旧主助手退出，但进程 PID {} 仍在运行。请先手动关闭旧 Pizza 窗口后重试。",
+		pid
+	))
 }
 
 fn workspace_meta_root() -> Option<PathBuf> {

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -13,6 +13,8 @@ fn main() {
 		.manage(bridge::BridgeState::default())
 		.invoke_handler(tauri::generate_handler![
 			bridge::init_sidecar,
+			bridge::main_agent_status,
+			bridge::stop_main_agent,
 			bridge::stop_sidecar,
 			bridge::rpc_command,
 			bridge::new_workspace,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,12 +6,16 @@ import Layout from "@/components/Layout";
 import AgentView from "@/views/AgentView";
 import SettingsView from "@/views/SettingsView";
 import PluginsView from "@/views/PluginsView";
-import { subscribeSidecarExit, subscribeEvents, initSidecar, sendCommandAwait, listWorkspaces, restartSidecar } from "@/lib/transport";
+import { subscribeSidecarExit, subscribeEvents, initSidecar, sendCommandAwait, listWorkspaces, restartSidecar, stopMainAgent } from "@/lib/transport";
 import { BrandIcon } from "@/components/BrandIcon";
 import type { RpcSessionState, WorkspaceMeta } from "@/lib/types";
 
 function isTauri(): boolean {
 	return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+function isMainAgentConflictError(message: string): boolean {
+	return message.includes("Another main agent instance is already running");
 }
 
 function AppInner() {
@@ -25,6 +29,7 @@ function AppInner() {
 	const [waitingForWorkspace, setWaitingForWorkspace] = useState(false);
 	const [workspaces, setWorkspaces] = useState<WorkspaceMeta[]>([]);
 	const [streamingCwds, setStreamingCwds] = useState<Set<string>>(new Set());
+	const [recoveringMainAgent, setRecoveringMainAgent] = useState(false);
 	const sidecarStartedRef = useRef(false);
 	// Auto-restart bookkeeping: per-cwd restart count, reset to 0 when a
 	// sidecar becomes ready. Capped at 3 attempts with exponential backoff
@@ -128,6 +133,20 @@ function AppInner() {
 	const handleDeleteWorkspace = useCallback((workspaceId: string) => {
 		setWorkspaces((prev) => prev.filter((ws) => ws.workspace_id !== workspaceId));
 	}, []);
+
+	const handleRecoverMainAgent = useCallback(async () => {
+		setRecoveringMainAgent(true);
+		try {
+			await stopMainAgent();
+			setInitError(null);
+			await startWithWorkspace("~/.pizza/main");
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			setInitError(msg);
+		} finally {
+			setRecoveringMainAgent(false);
+		}
+	}, [startWithWorkspace]);
 
 	// Refresh the session state from the sidecar. Used after settings that
 	// don't emit a dedicated event (e.g. toggling safe mode) so the root
@@ -284,23 +303,61 @@ function AppInner() {
 	}, [state, navigate, location.pathname, location.search]);
 
 	if (initError) {
+		const mainAgentConflict = isMainAgentConflictError(initError);
 		return (
 			<PxlKitSurfaceProvider surface="pixel">
 				<div className="flex h-screen items-center justify-center bg-bg">
-					<div className="flex max-w-md flex-col items-center gap-4 px-6 text-center">
+					<div className="flex max-w-lg flex-col items-center gap-4 px-6 text-center">
 						<BrandIcon size={48} className="text-danger" />
-						<p className="font-mono text-sm text-fg">{t("agent.failedToStartWorkspace")}</p>
-						<p className="font-mono text-xs text-muted">{initError}</p>
-						<button
-							type="button"
-							onClick={() => {
-								setInitError(null);
-								startWithWorkspace("~/.pizza/main");
-							}}
-							className="mt-2 rounded-md border border-border bg-surface-2 px-4 py-2 text-sm text-fg transition-colors hover:bg-surface-2/80"
-						>
-							{t("common.backToAgent")}
-						</button>
+						<p className="font-mono text-sm text-fg">
+							{mainAgentConflict ? t("agent.mainConflictTitle") : t("agent.failedToStartWorkspace")}
+						</p>
+						{mainAgentConflict ? (
+							<>
+								<p className="max-w-md text-sm leading-6 text-muted">{t("agent.mainConflictBody")}</p>
+								<details className="w-full text-left">
+									<summary className="cursor-pointer font-mono text-xs text-muted">{t("agent.errorDetails")}</summary>
+									<pre className="mt-2 max-h-36 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-surface-2 p-3 text-xs text-muted">
+										{initError}
+									</pre>
+								</details>
+								<div className="mt-2 flex flex-wrap justify-center gap-3">
+									<button
+										type="button"
+										disabled={recoveringMainAgent}
+										onClick={handleRecoverMainAgent}
+										className="rounded-md border border-accent bg-accent/15 px-4 py-2 text-sm text-accent transition-colors hover:bg-accent/25 disabled:cursor-not-allowed disabled:opacity-60"
+									>
+										{recoveringMainAgent ? t("agent.restartingMainAgent") : t("agent.stopOldAndRestart")}
+									</button>
+									<button
+										type="button"
+										disabled={recoveringMainAgent}
+										onClick={() => {
+											setInitError(null);
+											startWithWorkspace("~/.pizza/main");
+										}}
+										className="rounded-md border border-border bg-surface-2 px-4 py-2 text-sm text-fg transition-colors hover:bg-surface-2/80 disabled:cursor-not-allowed disabled:opacity-60"
+									>
+										{t("agent.retryStart")}
+									</button>
+								</div>
+							</>
+						) : (
+							<>
+								<p className="font-mono text-xs text-muted">{initError}</p>
+								<button
+									type="button"
+									onClick={() => {
+										setInitError(null);
+										startWithWorkspace("~/.pizza/main");
+									}}
+									className="mt-2 rounded-md border border-border bg-surface-2 px-4 py-2 text-sm text-fg transition-colors hover:bg-surface-2/80"
+								>
+									{t("common.backToAgent")}
+								</button>
+							</>
+						)}
 					</div>
 				</div>
 			</PxlKitSurfaceProvider>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -47,7 +47,13 @@
     "readyPrompt": "Ready. Ask anything about this project.",
     "sidecarExited": "Sidecar exited (code {{code}})",
     "agentError": "Agent error ({{reason}})",
-    "failedToStartWorkspace": "Failed to start workspace"
+    "failedToStartWorkspace": "Failed to start workspace",
+    "mainConflictTitle": "Another main agent is running",
+    "mainConflictBody": "An older Pizza main agent is still using ~/.pizza/main. This usually means another window, an older app bundle, or a recently closed process is still alive. Stop the old agent, then restart this window.",
+    "stopOldAndRestart": "Stop old agent and restart",
+    "restartingMainAgent": "Restarting...",
+    "retryStart": "Retry start",
+    "errorDetails": "Error details"
   },
   "composer": {
     "placeholder": "Type anything",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -47,7 +47,13 @@
     "readyPrompt": "就绪。可以问关于此项目的任何问题。",
     "sidecarExited": "Sidecar 已退出 (代码 {{code}})",
     "agentError": "Agent 错误 ({{reason}})",
-    "failedToStartWorkspace": "启动工作区失败"
+    "failedToStartWorkspace": "启动工作区失败",
+    "mainConflictTitle": "另一个主助手正在运行",
+    "mainConflictBody": "检测到旧的 Pizza 主助手还占用着 ~/.pizza/main。通常是另一个窗口、旧安装包，或刚退出但进程还没结束。可以先停止旧主助手，再重新启动当前窗口。",
+    "stopOldAndRestart": "停止旧助手并重启",
+    "restartingMainAgent": "正在重启...",
+    "retryStart": "重试启动",
+    "errorDetails": "错误详情"
   },
   "composer": {
     "placeholder": "随心输入",

--- a/apps/web/src/lib/transport.ts
+++ b/apps/web/src/lib/transport.ts
@@ -174,6 +174,25 @@ export async function initSidecar(cwd?: string): Promise<Record<string, unknown>
 	}
 }
 
+export interface MainAgentStatus {
+	running: boolean;
+	pid?: number | null;
+	command?: string | null;
+	lockPath: string;
+}
+
+export async function mainAgentStatus(): Promise<MainAgentStatus | null> {
+	if (!isTauri()) return null;
+	const core = await import("@tauri-apps/api/core");
+	return await core.invoke<MainAgentStatus>("main_agent_status");
+}
+
+export async function stopMainAgent(): Promise<MainAgentStatus | null> {
+	if (!isTauri()) return null;
+	const core = await import("@tauri-apps/api/core");
+	return await core.invoke<MainAgentStatus>("stop_main_agent");
+}
+
 export async function getSessionState(timeoutMs = 5000): Promise<RpcSessionState | null> {
 	const r = await sendCommandAwait<RpcSessionState>({ type: "get_state" }, timeoutMs);
 	return r.data ?? null;


### PR DESCRIPTION
## Summary
- detect the common `Another main agent instance is already running` startup failure and show a friendly recovery screen
- add Tauri commands to inspect and safely stop the locked main-agent process from `~/.pizza/main/.lock`
- let users stop the old main agent and restart the current workspace without manually hunting for the old process

## Verification
- `cargo fmt --check && cargo check` in `apps/desktop`
- `PATH=/Users/mac/.n/bin:$PATH npm run build`
- `PATH=/Users/mac/.n/bin:$PATH bun run build` in `apps/web`
- `PATH=/Users/mac/.n/bin:$PATH PIZZA_OFFLINE=1 npx vitest --run test/ai-client.test.ts test/model-registry.test.ts --no-file-parallelism --poolOptions.forks.singleFork`
- `PATH=/Users/mac/.n/bin:$PATH npm run build:desktop`
