### PR TITLE
fix(desktop): pass isize 0 for CreateFileW htemplatefile HANDLE

### DIFF
--- a/apps/desktop/src/gateway_channel.rs
+++ b/apps/desktop/src/gateway_channel.rs
@@ -523,7 +523,7 @@ fn windows_connect_pipe(pipe_name: &str) -> Result<std::fs::File, String> {
 			std::ptr::null(),
 			OPEN_EXISTING,
 			FILE_ATTRIBUTE_NORMAL,
-			core::ptr::null(),
+			0,
 		)
 	};
 	if handle == INVALID_HANDLE_VALUE {


### PR DESCRIPTION
## Summary
- Fix Windows desktop build type mismatch: in windows-sys 0.52, `HANDLE` is `isize`, not a raw pointer, so `core::ptr::null()` (which returns `*const T`) causes a type mismatch for the `htemplatefile` argument of `CreateFileW`. Pass `0` instead.

Follow-up to #50, which fixed the import errors but exposed this type mismatch when the Windows build actually compiled.

#### Test plan
- [ ] CI passes (Desktop fmt + check on Linux)
- [ ] Windows desktop build succeeds (verified via workflow_dispatch)

Generated with [Devin](https://devin.ai)