### PR TITLE
fix(desktop): increase provider test token budget

### DIFF
--- a/apps/desktop/src/bridge.rs
+++ b/apps/desktop/src/bridge.rs
@@ -2461,7 +2461,7 @@ pub async fn test_custom_provider(
 		let url = join_api_path(&base_url, "/v1/messages");
 		let body = serde_json::json!({
 			"model": model_id,
-			"max_tokens": 32,
+			"max_tokens": 1024,
 			"messages": [{ "role": "user", "content": "hi" }]
 		});
 		(
@@ -2476,7 +2476,7 @@ pub async fn test_custom_provider(
 		let url = join_api_path(&base_url, "/chat/completions");
 		let body = serde_json::json!({
 			"model": model_id,
-			"max_tokens": 32,
+			"max_tokens": 1024,
 			"stream": false,
 			"messages": [{ "role": "user", "content": "hi" }]
 		});

--- a/apps/web/scripts/dev-bridge.mjs
+++ b/apps/web/scripts/dev-bridge.mjs
@@ -157,7 +157,7 @@ async function testCustomProvider(input) {
 				},
 				body: {
 					model,
-					max_tokens: 32,
+					max_tokens: 1024,
 					messages: [{ role: "user", content: "hi" }],
 				},
 			}
@@ -169,7 +169,7 @@ async function testCustomProvider(input) {
 				},
 				body: {
 					model,
-					max_tokens: 32,
+					max_tokens: 1024,
 					stream: false,
 					messages: [{ role: "user", content: "hi" }],
 				},


### PR DESCRIPTION
## Summary
- increase custom provider test max_tokens from 32 to 1024
- keep the desktop bridge and web dev bridge test behavior aligned

## Tests
- node --check apps/web/scripts/dev-bridge.mjs
- cargo check
- PIZZA_OFFLINE=1 npm test (fails in this environment because bun:sqlite is unavailable)