### PR TITLE
feat(desktop): add computer-use permission setup

### DIFF
--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -440,7 +440,24 @@
       "installing": "Installing…",
       "uninstall": "Uninstall",
       "uninstalling": "Uninstalling…",
-      "actions": "Actions"
+      "actions": "Actions",
+      "permissions": {
+        "checking": "Checking desktop automation permissions",
+        "checkSlow": "Permission detection is taking longer than expected. This usually means macOS permissions are still off; open Settings, enable them, then recheck.",
+        "ready": "Desktop automation permissions are ready",
+        "needsSetup": "macOS permissions still need setup",
+        "accessibility": "Accessibility",
+        "accessibilityHint": "Lets Pizza read controls and perform clicks, typing, and key presses.",
+        "screenRecording": "Screen Recording",
+        "screenRecordingHint": "Lets Pizza read screenshots of approved windows so the model can see them.",
+        "detecting": "Checking",
+        "granted": "On",
+        "missing": "Off",
+        "openSettings": "Open Settings",
+        "recheck": "Recheck",
+        "afterOpen": "After Settings opens, enable pizza-computer-use or Pizza Computer Use, then return here and recheck.",
+        "stillMissing": "Some permissions are still off. Enable the missing toggles, then recheck."
+      }
     },
     "mcp": {
       "comingSoon": "MCP servers coming soon",

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -440,7 +440,24 @@
       "installing": "安装中…",
       "uninstall": "卸载",
       "uninstalling": "卸载中…",
-      "actions": "操作"
+      "actions": "操作",
+      "permissions": {
+        "checking": "正在检测电脑自动化权限",
+        "checkSlow": "检测耗时较久。通常是 macOS 权限还没开启,可以先打开系统设置开启权限,再回来重新检测。",
+        "ready": "电脑自动化权限已就绪",
+        "needsSetup": "还需要开启 macOS 权限",
+        "accessibility": "辅助功能",
+        "accessibilityHint": "用于读取按钮、输入框等控件,并执行点击、输入和按键。",
+        "screenRecording": "屏幕录制",
+        "screenRecordingHint": "用于读取已授权窗口的截图,让模型能看见窗口内容。",
+        "detecting": "检测中",
+        "granted": "已开启",
+        "missing": "未开启",
+        "openSettings": "打开系统设置",
+        "recheck": "重新检测",
+        "afterOpen": "打开设置后,请把 pizza-computer-use 或 Pizza Computer Use 的开关打开,再回到这里重新检测。",
+        "stillMissing": "还有权限未开启。请打开对应开关后重新检测。"
+      }
     },
     "mcp": {
       "comingSoon": "MCP 即将推出",

--- a/apps/web/src/lib/transport.ts
+++ b/apps/web/src/lib/transport.ts
@@ -436,6 +436,26 @@ export interface ExtensionInfo {
 	builtinCommandCount: number;
 }
 
+export type ExtensionPermissionKind = "accessibility" | "screenRecording";
+
+export interface ExtensionPermissionInfo {
+	kind: ExtensionPermissionKind;
+	label: string;
+	description: string;
+	granted: boolean;
+	required: boolean;
+}
+
+export interface ExtensionPermissionState {
+	extensionId: string;
+	supported: boolean;
+	installed: boolean;
+	ready: boolean;
+	helperPath?: string;
+	message?: string;
+	permissions: ExtensionPermissionInfo[];
+}
+
 /** List all extensions (built-in + user-installed), including disabled built-ins. */
 export async function getExtensions(): Promise<ExtensionInfo[]> {
 	try {
@@ -475,6 +495,45 @@ export async function uninstallExtension(
 		120000,
 	);
 	return { ok: r.data?.ok ?? false, message: r.data?.message ?? "", installed: r.data?.installed ?? false };
+}
+
+export async function getExtensionPermissions(id: string): Promise<ExtensionPermissionState> {
+	const r = await sendCommandAwait<ExtensionPermissionState>(
+		{ type: "get_extension_permissions", extensionId: id },
+		30000,
+	);
+	return r.data ?? {
+		extensionId: id,
+		supported: false,
+		installed: false,
+		ready: false,
+		permissions: [],
+	};
+}
+
+export async function recheckExtensionPermissions(id: string): Promise<ExtensionPermissionState> {
+	const r = await sendCommandAwait<ExtensionPermissionState>(
+		{ type: "recheck_extension_permissions", extensionId: id },
+		30000,
+	);
+	return r.data ?? {
+		extensionId: id,
+		supported: false,
+		installed: false,
+		ready: false,
+		permissions: [],
+	};
+}
+
+export async function openExtensionPermissionSettings(
+	id: string,
+	permissionKind: ExtensionPermissionKind,
+): Promise<{ ok: boolean; message: string }> {
+	const r = await sendCommandAwait<{ ok: boolean; message: string }>(
+		{ type: "open_extension_permission_settings", extensionId: id, permissionKind },
+		8000,
+	);
+	return { ok: r.data?.ok ?? false, message: r.data?.message ?? "" };
 }
 
 // --- Skills.sh directory ---

--- a/apps/web/src/views/PluginsView.tsx
+++ b/apps/web/src/views/PluginsView.tsx
@@ -13,12 +13,17 @@ import {
 	setExtensionEnabled,
 	installExtension,
 	uninstallExtension,
+	getExtensionPermissions,
+	recheckExtensionPermissions,
+	openExtensionPermissionSettings,
 	openExternal,
 	type SkillsShSkill,
 	type SkillInfo,
 	type ExtensionInfo,
+	type ExtensionPermissionKind,
+	type ExtensionPermissionState,
 } from "@/lib/transport";
-import { ArrowLeft, ArrowRight, Puzzle, BookOpen, Radio, Settings, Plus, Search, ExternalLink, Download, Power, Trash2, Hash, Send } from "lucide-react";
+import { ArrowLeft, ArrowRight, Puzzle, BookOpen, Radio, Settings, Plus, Search, ExternalLink, Download, Power, Trash2, Hash, Send, Monitor, MousePointer2, RotateCw, ShieldCheck } from "lucide-react";
 import type { LayoutOutletContext } from "@/components/Layout";
 import { ChannelDialog } from "@/components/ChannelDialog";
 import {
@@ -30,6 +35,8 @@ import {
 } from "@/lib/channels";
 
 type PluginTab = "skills" | "extensions" | "channels";
+const PERMISSION_CHECK_SLOW_MS = 6000;
+const PERMISSION_OPEN_BUSY_MS = 3000;
 
 interface TabConfig {
 	key: PluginTab;
@@ -41,6 +48,21 @@ const TABS: TabConfig[] = [
 	{ key: "extensions", icon: Puzzle },
 	{ key: "channels", icon: Radio },
 ];
+
+function permissionFallbackState(
+	extensionId: string,
+	installed: boolean,
+	message: string,
+): ExtensionPermissionState {
+	return {
+		extensionId,
+		supported: true,
+		installed,
+		ready: false,
+		message,
+		permissions: [],
+	};
+}
 
 function InstalledSkillCard({
 	skill,
@@ -317,12 +339,20 @@ function ExtensionCard({
 	onToggle,
 	onInstall,
 	onUninstall,
+	permissionState,
+	permissionBusy,
+	onOpenPermission,
+	onRecheckPermissions,
 	busyId,
 }: {
 	ext: ExtensionInfo;
 	onToggle: (id: string, enabled: boolean) => void;
 	onInstall: (id: string) => void;
 	onUninstall: (id: string) => void;
+	permissionState?: ExtensionPermissionState;
+	permissionBusy: string | null;
+	onOpenPermission: (id: string, kind: ExtensionPermissionKind) => void;
+	onRecheckPermissions: (id: string) => void;
 	busyId: string | null;
 }) {
 	const { t } = useTranslation();
@@ -334,6 +364,7 @@ function ExtensionCard({
 	const notInstalledInstallable = ext.installable && !ext.installed;
 	const showToggle = ext.canToggle && !notInstalledInstallable;
 	const showEnabledBadge = !notInstalledInstallable;
+	const showPermissionGuide = ext.id === "computer-use" && ext.installable && ext.installed;
 	return (
 		<Card className="@container transition-colors hover:border-accent/40">
 			<div className="flex flex-col gap-3 @sm:flex-row @sm:items-start @sm:justify-between">
@@ -402,16 +433,186 @@ function ExtensionCard({
 					/>
 				</div>
 			</div>
+			{showPermissionGuide && (
+				<ExtensionPermissionGuide
+					extensionId={ext.id}
+					state={permissionState}
+					busy={permissionBusy}
+					onOpen={(kind) => onOpenPermission(ext.id, kind)}
+					onRecheck={() => onRecheckPermissions(ext.id)}
+				/>
+			)}
 		</Card>
+	);
+}
+
+function ExtensionPermissionGuide({
+	extensionId,
+	state,
+	busy,
+	onOpen,
+	onRecheck,
+}: {
+	extensionId: string;
+	state?: ExtensionPermissionState;
+	busy: string | null;
+	onOpen: (kind: ExtensionPermissionKind) => void;
+	onRecheck: () => void;
+}) {
+	const { t } = useTranslation();
+	const permissions = state?.permissions.length
+		? state.permissions
+		: [
+				{ kind: "accessibility" as const, label: "Accessibility", description: "", granted: false, required: true },
+				{ kind: "screenRecording" as const, label: "Screen Recording", description: "", granted: false, required: true },
+			];
+	const checking = !state;
+	const ready = state?.ready === true;
+	const missing = permissions.filter((permission) => permission.required && !permission.granted);
+	const busyRecheck = busy === `${extensionId}:recheck`;
+
+	return (
+		<div className={cn(
+			"mt-4 rounded-lg border px-3 py-3",
+			ready ? "border-success/30 bg-success/5" : "border-warning/30 bg-warning/5",
+		)}>
+			<div className="flex flex-col gap-2 @sm:flex-row @sm:items-center @sm:justify-between">
+				<div className="min-w-0">
+					<div className="flex items-center gap-2 text-xs font-medium text-fg">
+						<ShieldCheck className={cn("h-3.5 w-3.5", ready ? "text-success" : "text-warning")} />
+						<span>
+							{checking
+								? t("plugins.extensions.permissions.checking")
+								: ready
+									? t("plugins.extensions.permissions.ready")
+									: t("plugins.extensions.permissions.needsSetup")}
+						</span>
+					</div>
+					{state?.message && (
+						<p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-muted">{state.message}</p>
+					)}
+				</div>
+				<Button
+					size="sm"
+					tone="neutral"
+					variant="outline"
+					iconLeft={<RotateCw className="h-3.5 w-3.5" />}
+					loading={busyRecheck}
+					disabled={busy !== null || checking}
+					onClick={onRecheck}
+				>
+					{t("plugins.extensions.permissions.recheck")}
+				</Button>
+			</div>
+			<div className="mt-3 space-y-2">
+				{permissions.map((permission) => {
+					const Icon = permission.kind === "screenRecording" ? Monitor : MousePointer2;
+					const rowBusy = busy === `${extensionId}:${permission.kind}`;
+					return (
+						<div
+							key={permission.kind}
+							className="flex flex-col gap-2 rounded-md border border-border/70 bg-surface/70 px-3 py-2 @sm:flex-row @sm:items-center @sm:justify-between"
+						>
+							<div className="min-w-0">
+								<div className="flex items-center gap-2">
+									<Icon className="h-3.5 w-3.5 shrink-0 text-muted" />
+									<span className="text-xs font-medium text-fg">
+										{t(`plugins.extensions.permissions.${permission.kind}`)}
+									</span>
+									<Badge tone={permission.granted ? "success" : "warning"}>
+										{checking
+											? t("plugins.extensions.permissions.detecting")
+											: permission.granted
+											? t("plugins.extensions.permissions.granted")
+											: t("plugins.extensions.permissions.missing")}
+									</Badge>
+								</div>
+								<p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-muted">
+									{t(`plugins.extensions.permissions.${permission.kind}Hint`)}
+								</p>
+							</div>
+							{!checking && !permission.granted && (
+								<Button
+									size="sm"
+									tone="accent"
+									variant="soft"
+									iconRight={<ExternalLink className="h-3.5 w-3.5" />}
+									loading={rowBusy}
+									disabled={busy !== null}
+									onClick={() => onOpen(permission.kind)}
+								>
+									{t("plugins.extensions.permissions.openSettings")}
+								</Button>
+							)}
+						</div>
+					);
+				})}
+			</div>
+			{!checking && missing.length > 0 && (
+				<p className="mt-2 text-[11px] leading-relaxed text-muted">
+					{t("plugins.extensions.permissions.afterOpen")}
+				</p>
+			)}
+		</div>
 	);
 }
 
 function ExtensionsTab() {
 	const { t } = useTranslation();
 	const [extensions, setExtensions] = useState<ExtensionInfo[]>([]);
+	const [extensionPermissions, setExtensionPermissions] = useState<Record<string, ExtensionPermissionState>>({});
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState("");
 	const [reloadHint, setReloadHint] = useState(false);
+	const [permissionBusy, setPermissionBusy] = useState<string | null>(null);
+	const permissionRequestSeq = useRef(0);
+
+	const refreshPermissions = useCallback(async (exts: ExtensionInfo[]) => {
+		const permissionExts = exts.filter((ext) => ext.id === "computer-use" && ext.installable && ext.installed);
+		if (permissionExts.length === 0) {
+			setExtensionPermissions({});
+			return;
+		}
+		const ids = new Set(permissionExts.map((ext) => ext.id));
+		setExtensionPermissions((prev) => Object.fromEntries(
+			Object.entries(prev).filter(([id]) => ids.has(id)),
+		));
+		for (const ext of permissionExts) {
+			const requestId = ++permissionRequestSeq.current;
+			let settled = false;
+			const timeout = window.setTimeout(() => {
+				if (settled || permissionRequestSeq.current !== requestId) return;
+				setExtensionPermissions((prev) => ({
+					...prev,
+					[ext.id]: permissionFallbackState(
+						ext.id,
+						ext.installed,
+						t("plugins.extensions.permissions.checkSlow"),
+					),
+				}));
+			}, PERMISSION_CHECK_SLOW_MS);
+			void getExtensionPermissions(ext.id)
+				.then((result) => {
+					settled = true;
+					window.clearTimeout(timeout);
+					if (permissionRequestSeq.current !== requestId) return;
+					setExtensionPermissions((prev) => ({ ...prev, [ext.id]: result }));
+				})
+				.catch((e) => {
+					settled = true;
+					window.clearTimeout(timeout);
+					if (permissionRequestSeq.current !== requestId) return;
+					setExtensionPermissions((prev) => ({
+						...prev,
+						[ext.id]: permissionFallbackState(
+							ext.id,
+							ext.installed,
+							e instanceof Error ? e.message : String(e),
+						),
+					}));
+				});
+		}
+	}, [t]);
 
 	const refresh = useCallback(async () => {
 		try {
@@ -419,12 +620,13 @@ function ExtensionsTab() {
 			setError("");
 			const exts = await getExtensions();
 			setExtensions(exts);
+			setLoading(false);
+			void refreshPermissions(exts);
 		} catch (e) {
 			setError(e instanceof Error ? e.message : String(e));
-		} finally {
 			setLoading(false);
 		}
-	}, []);
+	}, [refreshPermissions]);
 
 	useEffect(() => {
 		refresh();
@@ -474,6 +676,71 @@ function ExtensionsTab() {
 
 	const handleInstall = useCallback((id: string) => runLifecycle(id, installExtension), [runLifecycle]);
 	const handleUninstall = useCallback((id: string) => runLifecycle(id, uninstallExtension), [runLifecycle]);
+
+	const handleOpenPermission = useCallback(async (id: string, kind: ExtensionPermissionKind) => {
+		if (permissionBusy) return;
+		setPermissionBusy(`${id}:${kind}`);
+		const busyTimeout = window.setTimeout(() => setPermissionBusy(null), PERMISSION_OPEN_BUSY_MS);
+		try {
+			const result = await openExtensionPermissionSettings(id, kind);
+			if (!result.ok && result.message) setInstallMessage(result.message);
+		} catch (e) {
+			setInstallMessage(e instanceof Error ? e.message : String(e));
+		} finally {
+			window.clearTimeout(busyTimeout);
+			setPermissionBusy(null);
+		}
+	}, [permissionBusy]);
+
+	const handleRecheckPermissions = useCallback(async (id: string) => {
+		if (permissionBusy) return;
+		setPermissionBusy(`${id}:recheck`);
+		const requestId = ++permissionRequestSeq.current;
+		let settled = false;
+		const ext = extensions.find((item) => item.id === id);
+		setExtensionPermissions((prev) => {
+			const next = { ...prev };
+			delete next[id];
+			return next;
+		});
+		const timeout = window.setTimeout(() => {
+			if (settled || permissionRequestSeq.current !== requestId) return;
+			setExtensionPermissions((prev) => ({
+				...prev,
+				[id]: permissionFallbackState(
+					id,
+					ext?.installed ?? true,
+					t("plugins.extensions.permissions.checkSlow"),
+				),
+			}));
+			setPermissionBusy(null);
+		}, PERMISSION_CHECK_SLOW_MS);
+		try {
+			const result = await recheckExtensionPermissions(id);
+			settled = true;
+			window.clearTimeout(timeout);
+			if (permissionRequestSeq.current !== requestId) return;
+			setExtensionPermissions((prev) => ({ ...prev, [id]: result }));
+			setInstallMessage(result.ready
+				? t("plugins.extensions.permissions.ready")
+				: t("plugins.extensions.permissions.stillMissing"));
+		} catch (e) {
+			settled = true;
+			window.clearTimeout(timeout);
+			if (permissionRequestSeq.current !== requestId) return;
+			setInstallMessage(e instanceof Error ? e.message : String(e));
+			setExtensionPermissions((prev) => ({
+				...prev,
+				[id]: permissionFallbackState(
+					id,
+					ext?.installed ?? true,
+					e instanceof Error ? e.message : String(e),
+				),
+			}));
+		} finally {
+			if (permissionRequestSeq.current === requestId) setPermissionBusy(null);
+		}
+	}, [extensions, permissionBusy, t]);
 
 	if (loading) {
 		return (
@@ -526,6 +793,10 @@ function ExtensionsTab() {
 							onToggle={handleToggle}
 							onInstall={handleInstall}
 							onUninstall={handleUninstall}
+							permissionState={extensionPermissions[ext.id]}
+							permissionBusy={permissionBusy}
+							onOpenPermission={handleOpenPermission}
+							onRecheckPermissions={handleRecheckPermissions}
 							busyId={busyId}
 						/>
 					))}

--- a/packages/protocol/index.ts
+++ b/packages/protocol/index.ts
@@ -293,6 +293,9 @@ export type RpcCommand =
 	| { id?: string; type: "set_extension_enabled"; extensionId: string; enabled: boolean }
 	| { id?: string; type: "install_extension"; extensionId: string }
 	| { id?: string; type: "uninstall_extension"; extensionId: string }
+	| { id?: string; type: "get_extension_permissions"; extensionId: string }
+	| { id?: string; type: "recheck_extension_permissions"; extensionId: string }
+	| { id?: string; type: "open_extension_permission_settings"; extensionId: string; permissionKind: RpcExtensionPermissionKind }
 	// Provider auth: reload in-memory credentials from auth.json (used after the
 	// desktop bridge edits auth.json out-of-band, so a model switch picks up the
 	// new key instead of the stale in-memory cache or an env-var fallback).
@@ -399,6 +402,26 @@ export interface RpcExtensionInfo {
 	commandCount: number;
 	/** Number of dynamic built-in cli commands this extension registers (e.g. computer-use's `_computer_use`). */
 	builtinCommandCount: number;
+}
+
+export type RpcExtensionPermissionKind = "accessibility" | "screenRecording";
+
+export interface RpcExtensionPermissionInfo {
+	kind: RpcExtensionPermissionKind;
+	label: string;
+	description: string;
+	granted: boolean;
+	required: boolean;
+}
+
+export interface RpcExtensionPermissionState {
+	extensionId: string;
+	supported: boolean;
+	installed: boolean;
+	ready: boolean;
+	helperPath?: string;
+	message?: string;
+	permissions: RpcExtensionPermissionInfo[];
 }
 
 // ============================================================================
@@ -538,6 +561,9 @@ export type RpcResponse =
 	| { id?: string; type: "response"; command: "set_extension_enabled"; success: true; data: { id: string; enabled: boolean; requiresReload: boolean } }
 	| { id?: string; type: "response"; command: "install_extension"; success: true; data: { extensionId: string; ok: boolean; message: string; installed: boolean } }
 	| { id?: string; type: "response"; command: "uninstall_extension"; success: true; data: { extensionId: string; ok: boolean; message: string; installed: boolean } }
+	| { id?: string; type: "response"; command: "get_extension_permissions"; success: true; data: RpcExtensionPermissionState }
+	| { id?: string; type: "response"; command: "recheck_extension_permissions"; success: true; data: RpcExtensionPermissionState }
+	| { id?: string; type: "response"; command: "open_extension_permission_settings"; success: true; data: { extensionId: string; ok: boolean; message: string } }
 	| { id?: string; type: "response"; command: "reload_providers"; success: true; data: { providers: string[] } }
 	| { id?: string; type: "response"; command: "get_scheduler_policy"; success: true; data: { policy: SchedulerPolicy } }
 	| { id?: string; type: "response"; command: "set_scheduler_policy"; success: true; data: { policy: SchedulerPolicy } }

--- a/packages/rpc/rpc-mode.ts
+++ b/packages/rpc/rpc-mode.ts
@@ -404,6 +404,44 @@ async function runExtensionLifecycle(
 	return task;
 }
 
+async function getExtensionPermissions(
+	facade: SessionFacade,
+	extensionId: string,
+	recheck = false,
+) {
+	const lc = getBuiltinExtensionLifecycle(extensionId);
+	const fn = recheck ? lc?.recheckPermissions : lc?.checkPermissions;
+	if (!fn) {
+		return {
+			extensionId,
+			supported: false,
+			installed: false,
+			ready: false,
+			message: "This extension does not expose OS permission status.",
+			permissions: [],
+		};
+	}
+	const cwd = facade.runtime?.cwd ?? process.cwd();
+	const result = await fn(cwd);
+	return { extensionId, ...result };
+}
+
+async function openExtensionPermissionSettings(
+	facade: SessionFacade,
+	extensionId: string,
+	permissionKind: "accessibility" | "screenRecording",
+) {
+	const lc = getBuiltinExtensionLifecycle(extensionId);
+	if (!lc?.openPermissionSettings) {
+		return {
+			ok: false,
+			message: "This extension does not support opening OS permission settings.",
+		};
+	}
+	const cwd = facade.runtime?.cwd ?? process.cwd();
+	return lc.openPermissionSettings(cwd, permissionKind);
+}
+
 
 /** One-line preview of a message for history_tree view / diff. */
 function formatMessagePreview(message: AgentMessage): string | undefined {
@@ -1278,6 +1316,35 @@ export async function runRpcModeWithFacade(
 				ok: result.ok,
 				message: result.message,
 				installed: result.installed,
+			});
+		}
+
+		case "get_extension_permissions": {
+			return success(
+				id,
+				"get_extension_permissions",
+				await getExtensionPermissions(facade, command.extensionId),
+			);
+		}
+
+		case "recheck_extension_permissions": {
+			return success(
+				id,
+				"recheck_extension_permissions",
+				await getExtensionPermissions(facade, command.extensionId, true),
+			);
+		}
+
+		case "open_extension_permission_settings": {
+			const result = await openExtensionPermissionSettings(
+				facade,
+				command.extensionId,
+				command.permissionKind,
+			);
+			return success(id, "open_extension_permission_settings", {
+				extensionId: command.extensionId,
+				ok: result.ok,
+				message: result.message,
 			});
 		}
 

--- a/packages/rpc/rpc-types.ts
+++ b/packages/rpc/rpc-types.ts
@@ -19,6 +19,9 @@ export {
 	type RpcForensicEvent,
 	type RpcSkillInfo,
 	type RpcExtensionInfo,
+	type RpcExtensionPermissionKind,
+	type RpcExtensionPermissionInfo,
+	type RpcExtensionPermissionState,
 	classifyLine,
 	PROTOCOL_VERSION,
 } from "@tomsun28/pizza-protocol";

--- a/src/builtin-extensions/computer-use/backend/platform/macos/permissions.ts
+++ b/src/builtin-extensions/computer-use/backend/platform/macos/permissions.ts
@@ -86,6 +86,33 @@ async function registerPermissions(signal?: AbortSignal): Promise<void> {
 	await macosHelper.command("registerPermissions", {}, { signal, timeoutMs: 15_000 });
 }
 
+export async function getMacosPermissionStatus(signal?: AbortSignal): Promise<PermissionStatus> {
+	await macosHelper.ensureInstalled(signal);
+	if (!(await macosHelper.ensureDaemon(signal))) {
+		throw new Error(`pi-computer-use helper app daemon did not start. Helper app: ${HELPER_APP_PATH}`);
+	}
+	await macosHelper.ensureProtocol(signal);
+	return checkPermissions(signal);
+}
+
+export async function registerMacosPermissionPrompts(signal?: AbortSignal): Promise<void> {
+	await macosHelper.ensureInstalled(signal);
+	if (!(await macosHelper.ensureDaemon(signal))) {
+		throw new Error(`pi-computer-use helper app daemon did not start. Helper app: ${HELPER_APP_PATH}`);
+	}
+	await macosHelper.ensureProtocol(signal);
+	await registerPermissions(signal);
+}
+
+export async function openMacosPermissionPane(kind: PermissionKind, signal?: AbortSignal): Promise<void> {
+	await macosHelper.command("openPermissionPane", { kind }, { signal });
+}
+
+export async function recheckMacosPermissions(signal?: AbortSignal): Promise<PermissionStatus> {
+	await macosHelper.restart(signal);
+	return getMacosPermissionStatus(signal);
+}
+
 export async function ensureMacosReady(
 	ctx: ExtensionContext,
 	state: PlatformReadyState,

--- a/src/builtin-extensions/computer-use/index.ts
+++ b/src/builtin-extensions/computer-use/index.ts
@@ -55,6 +55,12 @@ import {
   helperInstalled,
   macosHelperAppPath,
 } from "./cli-command.js";
+import {
+  getMacosPermissionStatus,
+  recheckMacosPermissions,
+  registerMacosPermissionPrompts,
+} from "./backend/platform/macos/permissions.js";
+import type { PermissionKind, PermissionStatus } from "./backend/permissions.js";
 
 /** Upstream package version the vendored backend was taken from. */
 export const UPSTREAM_VERSION = "0.5.1";
@@ -67,6 +73,122 @@ export const COMPUTER_USE_EXTENSION_ID = "computer-use";
 const UPSTREAM_PACKAGE = "@injaneity/pi-computer-use";
 
 /** Stable id used in `settings.disabledBuiltinExtensions`. */
+
+function formatPermissionState(status: PermissionStatus) {
+  const permissions = [
+    {
+      kind: "accessibility" as const,
+      label: "Accessibility",
+      description: "Allows Pizza Computer Use to read controls and click, type, or press keys in approved app windows.",
+      granted: status.accessibility,
+      required: true,
+    },
+    {
+      kind: "screenRecording" as const,
+      label: "Screen Recording",
+      description: "Allows Pizza Computer Use to read screenshots of approved windows when vision is enabled.",
+      granted: status.screenRecording,
+      required: true,
+    },
+  ];
+  return {
+    supported: true,
+    installed: true,
+    ready: permissions.every((permission) => permission.granted),
+    helperPath: macosHelperAppPath(),
+    permissions,
+  };
+}
+
+function unavailablePermissionState(message: string, installed = helperInstalled()) {
+  return {
+    supported: process.platform === "darwin",
+    installed,
+    ready: false,
+    helperPath: process.platform === "darwin" ? macosHelperAppPath() : undefined,
+    message,
+    permissions: [
+      {
+        kind: "accessibility" as const,
+        label: "Accessibility",
+        description: "Allows Pizza Computer Use to read controls and click, type, or press keys in approved app windows.",
+        granted: false,
+        required: true,
+      },
+      {
+        kind: "screenRecording" as const,
+        label: "Screen Recording",
+        description: "Allows Pizza Computer Use to read screenshots of approved windows when vision is enabled.",
+        granted: false,
+        required: true,
+      },
+    ],
+  };
+}
+
+function macosPermissionPaneUrl(kind: PermissionKind): string {
+  switch (kind) {
+    case "accessibility":
+      return "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+    case "screenRecording":
+      return "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture";
+  }
+}
+
+export async function getComputerUsePermissionStatus(_cwd: string) {
+  if (process.platform !== "darwin") {
+    return unavailablePermissionState(`computer-use permissions are currently managed only on macOS (detected ${process.platform}).`, false);
+  }
+  if (!helperInstalled()) {
+    return unavailablePermissionState("Install computer-use before granting macOS permissions.", false);
+  }
+  try {
+    return formatPermissionState(await getMacosPermissionStatus());
+  } catch (error) {
+    return unavailablePermissionState(error instanceof Error ? error.message : String(error), true);
+  }
+}
+
+export async function recheckComputerUsePermissionStatus(_cwd: string) {
+  if (process.platform !== "darwin") {
+    return unavailablePermissionState(`computer-use permissions are currently managed only on macOS (detected ${process.platform}).`, false);
+  }
+  if (!helperInstalled()) {
+    return unavailablePermissionState("Install computer-use before granting macOS permissions.", false);
+  }
+  try {
+    return formatPermissionState(await recheckMacosPermissions());
+  } catch (error) {
+    return unavailablePermissionState(error instanceof Error ? error.message : String(error), true);
+  }
+}
+
+export async function openComputerUsePermissionSettings(_cwd: string, kind: PermissionKind) {
+  if (process.platform !== "darwin") {
+    return {
+      ok: false,
+      message: `computer-use permissions are currently managed only on macOS (detected ${process.platform}).`,
+    };
+  }
+  if (!helperInstalled()) {
+    return { ok: false, message: "Install computer-use before opening permission settings." };
+  }
+  try {
+    const opened = await execCommand("/usr/bin/open", [macosPermissionPaneUrl(kind)], os.homedir(), { timeout: 5_000 });
+    if (opened.code !== 0) {
+      return {
+        ok: false,
+        message: opened.stderr || opened.stdout || "Failed to open macOS permission settings.",
+      };
+    }
+    return { ok: true, message: "Opened macOS permission settings." };
+  } catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
 
 function notify(
   ctx: ExtensionCommandContext,
@@ -148,7 +270,13 @@ export async function runComputerUseInstall(
     process.execPath,
     [setupScript, "--runtime"],
     pkgDir,
-    { timeout: 300_000 },
+    {
+      timeout: 300_000,
+      env: {
+        ELECTRON_RUN_AS_NODE: "1",
+        BUN_BE_BUN: "1",
+      },
+    },
   );
   if (setup.code !== 0) {
     return {
@@ -164,9 +292,26 @@ export async function runComputerUseInstall(
       message: `Helper installed, but rebranding failed: ${rebrand.message}`,
     };
   }
+  let permissionMessage =
+    "Open the permission buttons in Plugins → Extensions if Accessibility or Screen Recording is still missing.";
+  try {
+    await registerMacosPermissionPrompts();
+    const permissions = await getComputerUsePermissionStatus(_cwd);
+    if (permissions.ready) {
+      permissionMessage = "All macOS permissions are ready.";
+    } else {
+      const missing = permissions.permissions
+        .filter((permission) => permission.required && !permission.granted)
+        .map((permission) => permission.label)
+        .join(" and ");
+      permissionMessage = `${missing} still needs to be enabled in macOS System Settings.`;
+    }
+  } catch (error) {
+    permissionMessage = `Helper installed, but permission setup needs attention: ${error instanceof Error ? error.message : String(error)}`;
+  }
   return {
     ok: true,
-    message: `Helper installed at ${macosHelperAppPath()}. Grant Accessibility + Screen Recording when prompted (System Settings → Privacy & Security), then run /computer status.`,
+    message: `Helper installed at ${macosHelperAppPath()}. ${permissionMessage}`,
   };
 }
 

--- a/src/builtin-extensions/index.ts
+++ b/src/builtin-extensions/index.ts
@@ -23,6 +23,9 @@ import {
 	COMPUTER_USE_EXTENSION_ID,
 	checkComputerUseInstalled,
 	createComputerUseExtension,
+	getComputerUsePermissionStatus,
+	openComputerUsePermissionSettings,
+	recheckComputerUsePermissionStatus,
 	runComputerUseInstall,
 	runComputerUseUninstall,
 } from "./computer-use/index.js";
@@ -37,6 +40,25 @@ export interface ExtensionLifecycleResult {
 export interface ExtensionInstallState {
 	installed: boolean;
 	version?: string;
+}
+
+export type ExtensionPermissionKind = "accessibility" | "screenRecording";
+
+export interface ExtensionPermissionInfo {
+	kind: ExtensionPermissionKind;
+	label: string;
+	description: string;
+	granted: boolean;
+	required: boolean;
+}
+
+export interface ExtensionPermissionState {
+	supported: boolean;
+	installed: boolean;
+	ready: boolean;
+	helperPath?: string;
+	message?: string;
+	permissions: ExtensionPermissionInfo[];
 }
 
 export interface BuiltinExtension {
@@ -56,6 +78,12 @@ export interface BuiltinExtension {
 	install?: (cwd: string) => Promise<ExtensionLifecycleResult>;
 	/** Uninstall the external dependency. Only when installable. */
 	uninstall?: (cwd: string) => Promise<ExtensionLifecycleResult>;
+	/** Check OS/application permissions needed by the extension's external dependency. */
+	checkPermissions?: (cwd: string) => Promise<ExtensionPermissionState>;
+	/** Recheck permissions after the user changes OS settings. */
+	recheckPermissions?: (cwd: string) => Promise<ExtensionPermissionState>;
+	/** Open the OS settings pane for a missing permission. */
+	openPermissionSettings?: (cwd: string, kind: ExtensionPermissionKind) => Promise<ExtensionLifecycleResult>;
 }
 
 /**
@@ -82,6 +110,9 @@ export const BUILTIN_EXTENSIONS: readonly BuiltinExtension[] = [
 		checkInstalled: (cwd) => checkComputerUseInstalled(cwd),
 		install: (cwd) => runComputerUseInstall(cwd),
 		uninstall: (cwd) => runComputerUseUninstall(cwd),
+		checkPermissions: (cwd) => getComputerUsePermissionStatus(cwd),
+		recheckPermissions: (cwd) => recheckComputerUsePermissionStatus(cwd),
+		openPermissionSettings: (cwd, kind) => openComputerUsePermissionSettings(cwd, kind),
 	},
 ];
 
@@ -120,7 +151,7 @@ export function getBuiltinExtensionInfo(id: string): BuiltinExtensionInfo | unde
 /** Look up the install lifecycle (install/uninstall/checkInstalled) for a built-in id. */
 export function getBuiltinExtensionLifecycle(
 	id: string,
-): Pick<BuiltinExtension, "installable" | "checkInstalled" | "install" | "uninstall"> | undefined {
+): Pick<BuiltinExtension, "installable" | "checkInstalled" | "install" | "uninstall" | "checkPermissions" | "recheckPermissions" | "openPermissionSettings"> | undefined {
 	const ext = BUILTIN_EXTENSIONS.find((e) => e.id === id);
 	if (!ext) return undefined;
 	return {
@@ -128,5 +159,8 @@ export function getBuiltinExtensionLifecycle(
 		checkInstalled: ext.checkInstalled,
 		install: ext.install,
 		uninstall: ext.uninstall,
+		checkPermissions: ext.checkPermissions,
+		recheckPermissions: ext.recheckPermissions,
+		openPermissionSettings: ext.openPermissionSettings,
 	};
 }

--- a/src/core/exec.ts
+++ b/src/core/exec.ts
@@ -16,6 +16,8 @@ export interface ExecOptions {
 	timeout?: number;
 	/** Working directory */
 	cwd?: string;
+	/** Extra environment variables to merge into the login-shell environment. */
+	env?: NodeJS.ProcessEnv;
 }
 
 /**
@@ -48,7 +50,7 @@ export async function execCommand(
 			// context with a minimal PATH (e.g. macOS launchd/Tauri). Without this,
 			// `npm install -g agent-browser` fails with exit 1 because `npm` is not
 			// on the inherited PATH.
-			env: getShellEnv(),
+			env: { ...getShellEnv(), ...options?.env },
 		});
 
 		let stdout = "";


### PR DESCRIPTION
## Summary

- add macOS Accessibility and Screen Recording status checks for computer-use
- expose permission check, recheck, and System Settings actions through RPC
- add a guided permission setup panel to Plugins → Extensions
- pass the required runtime environment when installing the helper

## Verification

- `PATH=/Users/mac/.volta/tools/image/node/24.15.0/bin:$PATH PIZZA_OFFLINE=1 npm test` (137 files passed, 4 skipped; 1578 tests passed, 18 skipped)
- `npm run build`
- `cd apps/web && npm run lint`
- `cd apps/web && npm run build`
